### PR TITLE
Harden proxy IP trust and wallpaper upload validation

### DIFF
--- a/log.go
+++ b/log.go
@@ -24,6 +24,30 @@ import (
 )
 
 var trustedCIDRs []*net.IPNet
+var trustedProxyCIDRs = parseCIDRs([]string{
+	"173.245.48.0/20",
+	"103.21.244.0/22",
+	"103.22.200.0/22",
+	"103.31.4.0/22",
+	"141.101.64.0/18",
+	"108.162.192.0/18",
+	"190.93.240.0/20",
+	"188.114.96.0/20",
+	"197.234.240.0/22",
+	"198.41.128.0/17",
+	"162.158.0.0/15",
+	"104.16.0.0/13",
+	"104.24.0.0/14",
+	"172.64.0.0/13",
+	"131.0.72.0/22",
+	"2400:cb00::/32",
+	"2405:8100::/32",
+	"2405:b500::/32",
+	"2606:4700::/32",
+	"2803:f800::/32",
+	"2c0f:f248::/32",
+	"2a06:98c0::/29",
+})
 var scoreFile = "./json/ip_scores.json"
 var ipScores = map[string]int{}
 var ipScoresMutex sync.RWMutex
@@ -600,14 +624,77 @@ func secureHandler(next http.HandlerFunc) http.HandlerFunc {
 }
 
 func getIPAddress(r *http.Request) string {
-	if cf := r.Header.Get("CF-Connecting-IP"); cf != "" {
-		return cf
-	}
-	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	remoteIP, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
-		return r.RemoteAddr
+		remoteIP = r.RemoteAddr
 	}
-	return ip
+
+	if shouldTrustForwardedIP(remoteIP) {
+		if cf := strings.TrimSpace(r.Header.Get("CF-Connecting-IP")); cf != "" {
+			if parsed := net.ParseIP(cf); parsed != nil {
+				return parsed.String()
+			}
+		}
+
+		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+			parts := strings.Split(xff, ",")
+			for _, part := range parts {
+				candidate := strings.TrimSpace(part)
+				if parsed := net.ParseIP(candidate); parsed != nil {
+					return parsed.String()
+				}
+			}
+		}
+	}
+
+	return remoteIP
+}
+
+func shouldTrustForwardedIP(remoteIP string) bool {
+	if remoteIP == "" {
+		return false
+	}
+
+	if isPrivateOrLoopback(remoteIP) {
+		return true
+	}
+
+	ip := net.ParseIP(remoteIP)
+	if ip == nil {
+		return false
+	}
+
+	for _, cidr := range trustedProxyCIDRs {
+		if cidr.Contains(ip) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func parseCIDRs(cidrs []string) []*net.IPNet {
+	networks := make([]*net.IPNet, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		cidr = strings.TrimSpace(cidr)
+		if cidr == "" {
+			continue
+		}
+		if !strings.Contains(cidr, "/") {
+			if ip := net.ParseIP(cidr); ip != nil {
+				bits := 32
+				if ip.To4() == nil {
+					bits = 128
+				}
+				networks = append(networks, &net.IPNet{IP: ip, Mask: net.CIDRMask(bits, bits)})
+			}
+			continue
+		}
+		if _, network, err := net.ParseCIDR(cidr); err == nil {
+			networks = append(networks, network)
+		}
+	}
+	return networks
 }
 
 func sendDiscordWebhook(ip, level, method, path, ua, reqHash string) {

--- a/main.go
+++ b/main.go
@@ -424,7 +424,15 @@ func handleWeather(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleWallpaperUpload(w http.ResponseWriter, r *http.Request) {
-	r.ParseMultipartForm(10 << 20) // 最大10MB
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if err := r.ParseMultipartForm(10 << 20); err != nil {
+		http.Error(w, "ファイルを取得できません", http.StatusBadRequest)
+		return
+	}
 
 	file, handler, err := r.FormFile("wallpaper")
 	if err != nil {
@@ -433,17 +441,67 @@ func handleWallpaperUpload(w http.ResponseWriter, r *http.Request) {
 	}
 	defer file.Close()
 
-	filename := handler.Filename
-	filepath := "home/wallpapers/" + filename
+	if handler.Size <= 0 || handler.Size > 10<<20 {
+		http.Error(w, "許可されていないファイルサイズです", http.StatusBadRequest)
+		return
+	}
 
-	out, err := os.Create(filepath)
+	ext := strings.ToLower(filepath.Ext(handler.Filename))
+	allowedExts := map[string]bool{
+		".jpg": true, ".jpeg": true, ".png": true, ".gif": true, ".webp": true,
+	}
+	if !allowedExts[ext] {
+		http.Error(w, "対応していないファイル形式です", http.StatusBadRequest)
+		return
+	}
+
+	sniffBuf := make([]byte, 512)
+	n, err := file.Read(sniffBuf)
+	if err != nil && err != io.EOF {
+		http.Error(w, "ファイルの読み込みに失敗しました", http.StatusBadRequest)
+		return
+	}
+
+	contentType := http.DetectContentType(sniffBuf[:n])
+	allowedMIMEs := map[string]bool{
+		"image/jpeg": true,
+		"image/png":  true,
+		"image/gif":  true,
+		"image/webp": true,
+	}
+	if !allowedMIMEs[contentType] {
+		http.Error(w, "対応していないファイル形式です", http.StatusBadRequest)
+		return
+	}
+
+	filename := uuid.New().String() + ext
+	wallpaperDir := filepath.Clean("home/wallpapers")
+	if err := os.MkdirAll(wallpaperDir, 0755); err != nil {
+		http.Error(w, "ファイル保存に失敗しました", http.StatusInternalServerError)
+		return
+	}
+
+	destPath := filepath.Join(wallpaperDir, filename)
+	destPath = filepath.Clean(destPath)
+	if !strings.HasPrefix(destPath, wallpaperDir+string(os.PathSeparator)) {
+		http.Error(w, "不正なファイルパスです", http.StatusBadRequest)
+		return
+	}
+
+	out, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		http.Error(w, "ファイル保存に失敗しました", http.StatusInternalServerError)
 		return
 	}
 	defer out.Close()
-	io.Copy(out, file)
 
+	reader := io.MultiReader(bytes.NewReader(sniffBuf[:n]), file)
+	if _, err := io.Copy(out, reader); err != nil {
+		http.Error(w, "ファイル保存に失敗しました", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{
 		"status":   "success",
 		"filename": filename,


### PR DESCRIPTION
## Summary
- trust forwarded client IP headers only when requests come from known proxy networks and validate values before use
- tighten wallpaper uploads by enforcing file size and type checks, generating safe filenames, and writing only within the wallpapers directory

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e916b24194832aaae36e2c3131c410