### PR TITLE
Enhance subscription calendar integrations and devtools

### DIFF
--- a/getstatus/getstatus_main_unix.go
+++ b/getstatus/getstatus_main_unix.go
@@ -6,39 +6,131 @@
 
 package getstatus
 
-import "runtime"
+import (
+	"runtime"
+	"sync"
+)
 
 // Darwin
 func getDarwinStatus() (*PCStatus, error) {
 	status := &PCStatus{}
-	status.PC = runPS(`scutil --get ComputerName`)
-	status.Battery = runPS(`pmset -g batt | grep -Eo "\d+%" | head -1`)
-	status.WAN = runPS(`ping -c 1 -W 1 1.1.1.1 >/dev/null; if ($?) { "Active" } else { "Offline" }`)
-	status.Uptime = runPS(`uptime | awk '{print $3 " " $4 " " $5}'`)
-	status.CPU = runPS(`ps -A -o %cpu | awk '{s+=$1} END {print s "%"}'`)
-	status.Mem = runPS(`vm_stat | grep "Pages active" | awk '{print $3}'`)
+	type fieldResult struct {
+		field string
+		value string
+	}
+
+	commands := map[string]string{
+		"PC":         `scutil --get ComputerName`,
+		"Battery":    `pmset -g batt | grep -Eo "\d+%" | head -1`,
+		"WAN":        `ping -c 1 -W 1 1.1.1.1 >/dev/null; if ($?) { "Active" } else { "Offline" }`,
+		"Uptime":     `uptime | awk '{print $3 " " $4 " " $5}'`,
+		"CPU":        `ps -A -o %cpu | awk '{s+=$1} END {print s "%"}'`,
+		"Mem":        `vm_stat | grep "Pages active" | awk '{print $3}'`,
+		"DriveC":     `df -h / | awk 'NR==2{print $5 " (" $3 "/" $2 ")"}'`,
+		"MainWindow": `osascript -e 'tell application "System Events" to get name of (processes where frontmost is true)'`,
+	}
+
+	results := make(chan fieldResult, len(commands))
+	var wg sync.WaitGroup
+
+	for field, cmd := range commands {
+		wg.Add(1)
+		go func(field, cmd string) {
+			defer wg.Done()
+			results <- fieldResult{field: field, value: runPS(cmd)}
+		}(field, cmd)
+	}
+
+	wg.Wait()
+	close(results)
+
+	for res := range results {
+		switch res.field {
+		case "PC":
+			status.PC = res.value
+		case "Battery":
+			status.Battery = res.value
+		case "WAN":
+			status.WAN = res.value
+		case "Uptime":
+			status.Uptime = res.value
+		case "CPU":
+			status.CPU = res.value
+		case "Mem":
+			status.Mem = res.value
+		case "DriveC":
+			status.DriveC = res.value
+		case "MainWindow":
+			status.MainWindow = res.value
+		}
+	}
+
 	status.GPU0 = "N/A" // macOSでは実装予定なし
 	status.VRAM = "N/A" // macOSでは実装予定なし
-	status.DriveC = runPS(`df -h / | awk 'NR==2{print $5 " (" $3 "/" $2 ")"}'`)
-	status.MainWindow = runPS(`osascript -e 'tell application "System Events" to get name of (processes where frontmost is true)'`)
+
 	return status, nil
 }
 
 // Linux
 func getLinuxStatus() (*PCStatus, error) {
 	status := &PCStatus{}
-	status.PC = runPS(`hostname`)
-	status.Battery = runPS(`cat /sys/class/power_supply/BAT0/capacity`) // バッテリーが存在しない場合は変更してください。
-	status.WAN = runPS(`ping -c 1 -W 1 1.1.1.1 >/dev/null; if ($?) { "Active" } else { "Offline" }`)
-	status.Uptime = runPS(`uptime -p`)
-	status.CPU = runPS(`top -bn1 | grep "Cpu(s)" | awk '{print $2 + $4}' | ForEach-Object { "$_%" }`)
-	status.Mem = runPS(`free -m | awk 'NR==2{printf "%.0f%% (%dMB/%dMB)", $3*100/$2, $3, $2 }'`)
-	status.GPU0 = runPS(`nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits | Select-Object -First 1`)
-	status.VRAM = runPS(`nvidia-smi --query-gpu=memory.used,memory.total --format=csv,noheader,nounits | ForEach-Object {
+	type fieldResult struct {
+		field string
+		value string
+	}
+
+	commands := map[string]string{
+		"PC":      `hostname`,
+		"Battery": `cat /sys/class/power_supply/BAT0/capacity`,
+		"WAN":     `ping -c 1 -W 1 1.1.1.1 >/dev/null; if ($?) { "Active" } else { "Offline" }`,
+		"Uptime":  `uptime -p`,
+		"CPU":     `top -bn1 | grep "Cpu(s)" | awk '{print $2 + $4}' | ForEach-Object { "$_%" }`,
+		"Mem":     `free -m | awk 'NR==2{printf "%.0f%% (%dMB/%dMB)", $3*100/$2, $3, $2 }'`,
+		"GPU0":    `nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits | Select-Object -First 1`,
+		"VRAM": `nvidia-smi --query-gpu=memory.used,memory.total --format=csv,noheader,nounits | ForEach-Object {
         $p=$_.Split(",");$u=[double]$p[0];$t=[double]$p[1];$pr=[math]::Round(($u/$t)*100,0);
         "$pr% ($u" + "MiB/$t" + "MiB)"
-    } | Select-Object -First 1`)
-	status.DriveC = runPS(`df -h / | awk 'NR==2{print $5 " (" $3 "/" $2 ")"}'`)
+    } | Select-Object -First 1`,
+		"DriveC": `df -h / | awk 'NR==2{print $5 " (" $3 "/" $2 ")"}'`,
+	}
+
+	results := make(chan fieldResult, len(commands))
+	var wg sync.WaitGroup
+
+	for field, cmd := range commands {
+		wg.Add(1)
+		go func(field, cmd string) {
+			defer wg.Done()
+			results <- fieldResult{field: field, value: runPS(cmd)}
+		}(field, cmd)
+	}
+
+	wg.Wait()
+	close(results)
+
+	for res := range results {
+		switch res.field {
+		case "PC":
+			status.PC = res.value
+		case "Battery":
+			status.Battery = res.value
+		case "WAN":
+			status.WAN = res.value
+		case "Uptime":
+			status.Uptime = res.value
+		case "CPU":
+			status.CPU = res.value
+		case "Mem":
+			status.Mem = res.value
+		case "GPU0":
+			status.GPU0 = res.value
+		case "VRAM":
+			status.VRAM = res.value
+		case "DriveC":
+			status.DriveC = res.value
+		}
+	}
+
 	status.MainWindow = "N/A" // Linuxでは未実装
 
 	return status, nil

--- a/home/account.js
+++ b/home/account.js
@@ -53,6 +53,10 @@ document.addEventListener("DOMContentLoaded", () => {
             setupAccountModal();
         });
     };
+
+    if (isLoggedIn()) {
+        notifyAuthState(getLoggedInUser());
+    }
 });
 
 document.getElementById("openAccManage").addEventListener("click", () => {
@@ -72,12 +76,18 @@ function getLoggedInUser() {
 
 function saveLoginState(user) {
     localStorage.setItem("tabdock_user", JSON.stringify(user));
+    notifyAuthState(user);
 }
 
 function logout() {
     localStorage.removeItem("tabdock_user");
     Swal.fire("ログアウト", "正常にログアウトしました。", "success");
+    notifyAuthState(null);
     setupAccountModal();
+}
+
+function notifyAuthState(user) {
+    window.dispatchEvent(new CustomEvent('auth:state-changed', { detail: { user } }));
 }
 
 function setupAccountModal() {
@@ -179,6 +189,9 @@ function setupLoggedInModal(modal) {
                     <div class="bg-black/20 rounded-lg p-4">
                         <h3 class="text-lg font-semibold mb-3">詳細管理</h3>
                         <div class="space-y-2">
+                            <button id="subscriptionManageBtn" class="w-full text-left text-xs text-white/70 hover:text-white/90 py-2 px-3 rounded hover:bg-white/10 transition-colors">
+                                サブスクリプション管理
+                            </button>
                             <button class="w-full text-left text-xs text-white/70 hover:text-white/90 py-2 px-3 rounded hover:bg-white/10 transition-colors">
                                 データエクスポート
                             </button>
@@ -197,6 +210,8 @@ function setupLoggedInModal(modal) {
             </div>
         </div>
     `;
+
+    window.dispatchEvent(new CustomEvent('account:modal-ready'));
     
     setupLoggedInEventListeners();
 }
@@ -286,7 +301,9 @@ function setupLoginModal(modal) {
             </div>
         </div>
     `;
-    
+
+    window.dispatchEvent(new CustomEvent('account:modal-ready'));
+
     setupAccountEventListeners();
 }
 

--- a/home/index.html
+++ b/home/index.html
@@ -167,7 +167,7 @@
         <div id="scheduleTypeModal" class="hidden td-modal-overlay z-50">
             <div class="td-modal-panel td-modal-sm">
                 <h2 class="text-xl font-bold mb-3">予定の種類を選択</h2>
-                
+
                 <div class="space-y-3">
                     <button id="openRegularScheduleBtn" class="w-full bg-blue-600 hover:bg-blue-500 text-white p-3 rounded transition-colors flex items-center justify-center space-x-2">
                         <span>通常予定を追加</span>
@@ -185,6 +185,91 @@
                 <div class="text-right mt-4">
                     <button id="closeScheduleTypeModal" class="px-4 py-2 bg-gray-600 hover:bg-gray-500 rounded">キャンセル</button>
                 </div>
+            </div>
+        </div>
+
+        <!-- サブスクリプション追加モーダル -->
+        <div id="subscriptionModal" class="hidden td-modal-overlay z-[70]">
+            <div class="td-modal-panel td-modal-md max-h-[90vh] overflow-y-auto">
+                <h2 class="text-2xl font-bold mb-4 text-white">サブスクリプションスケジュールを追加</h2>
+                <form id="subscriptionForm" class="space-y-4">
+                    <div>
+                        <label class="block text-sm font-medium text-gray-200">サービス名</label>
+                        <input type="text" name="serviceName" required class="mt-1 block w-full rounded-md bg-gray-800 text-white border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-200">プラン名</label>
+                        <input type="text" name="planName" required class="mt-1 block w-full rounded-md bg-gray-800 text-white border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                    </div>
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <label class="block text-sm font-medium text-gray-200">金額</label>
+                            <input type="number" name="amount" step="0.01" min="0" required class="mt-1 block w-full rounded-md bg-gray-800 text-white border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                        </div>
+                        <div>
+                            <label class="block text-sm font-medium text-gray-200">通貨</label>
+                            <select name="currency" required class="mt-1 block w-full rounded-md bg-gray-800 text-white border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                <option value="" selected disabled>選択してください</option>
+                                <option value="JPY">JPY</option>
+                                <option value="USD">USD</option>
+                                <option value="EUR">EUR</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-200">課金サイクル</label>
+                        <select name="billingCycle" required class="mt-1 block w-full rounded-md bg-gray-800 text-white border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                            <option value="" selected disabled>選択してください</option>
+                            <option value="monthly">月額</option>
+                            <option value="yearly">年額</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-200">決済方法</label>
+                        <select name="paymentMethod" required class="mt-1 block w-full rounded-md bg-gray-800 text-white border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                            <option value="" selected disabled>選択してください</option>
+                            <option value="CC">クレジットカード</option>
+                            <option value="PayPal">PayPal</option>
+                            <option value="GooglePay">Google Pay</option>
+                            <option value="ApplePay">Apple Pay</option>
+                            <option value="PayPay">PayPay</option>
+                            <option value="AmazonPay">Amazon Pay</option>
+                            <option value="Other">その他</option>
+                        </select>
+                    </div>
+                    <div id="paymentDetails" class="hidden space-y-4">
+                        <div id="ccDetails" class="hidden">
+                            <label class="block text-sm font-medium text-gray-200">カード末尾4桁（任意）</label>
+                            <input type="text" name="cardLastFour" pattern="[0-9]{4}" maxlength="4" class="mt-1 block w-full rounded-md bg-gray-800 text-white border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                        </div>
+                        <div id="paypalDetails" class="hidden space-y-1">
+                            <label class="block text-sm font-medium text-gray-200">PayPalメールアドレス（任意）</label>
+                            <input type="email" name="paypalEmail" class="mt-1 block w-full rounded-md bg-gray-800 text-white border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                        </div>
+                        <div id="otherDetails" class="hidden space-y-3">
+                            <div>
+                                <label class="block text-sm font-medium text-gray-200">決済方法名</label>
+                                <input type="text" name="otherPaymentMethod" class="mt-1 block w-full rounded-md bg-gray-800 text-white border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-gray-200">ラベル（任意）</label>
+                                <input type="text" name="otherPaymentLabel" class="mt-1 block w-full rounded-md bg-gray-800 text-white border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                            </div>
+                        </div>
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-200">次回支払日</label>
+                        <input type="date" name="nextPaymentDate" required class="mt-1 block w-full rounded-md bg-gray-800 text-white border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                    </div>
+                    <div class="flex justify-end space-x-3 pt-4">
+                        <button type="button" id="cancelSubscription" class="px-4 py-2 bg-gray-700 text-white rounded-md hover:bg-gray-600 transition-colors">
+                            キャンセル
+                        </button>
+                        <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition-colors">
+                            保存
+                        </button>
+                    </div>
+                </form>
             </div>
         </div>
 
@@ -668,6 +753,11 @@
                             </div>
 
                             <div class="flex justify-between">
+                                <span>カレンダーを再生成</span>
+                                <button id="regenerateCalendarBtn" class="bg-indigo-600 hover:bg-indigo-500 px-3 py-1 rounded">再生成</button>
+                            </div>
+
+                            <div class="flex justify-between">
                                 <span>JavaScriptロード状態確認</span>
                                 <button id="checkJsStatusBtn" class="bg-blue-600 hover:bg-blue-500 px-3 py-1 rounded">確認</button>
                             </div>
@@ -698,6 +788,11 @@
                             </div>
 
                             <div class="flex justify-between">
+                                <span>画面焼け防止モード</span>
+                                <button id="toggleBurnInProtectionBtn" class="bg-slate-600 hover:bg-slate-500 px-3 py-1 rounded">起動</button>
+                            </div>
+
+                            <div class="flex justify-between">
                                 <span>ページ再読み込み</span>
                                 <button id="reloadPageBtn" class="bg-gray-600 hover:bg-gray-500 px-3 py-1 rounded">再読込</button>
                             </div>
@@ -713,6 +808,15 @@
                 <!-- アカウント管理 -->
                 <div id="accountModal" class="hidden fixed inset-0 bg-black/50 flex justify-center items-center z-[60]">
                     <!-- 動的生成 -->
+                </div>
+
+                <!-- 画面焼け防止オーバーレイ -->
+                <div id="burnInOverlay" class="hidden">
+                    <div class="burnin-content">
+                        <div class="burnin-pulse"></div>
+                        <p class="burnin-text">画面焼け防止モード<br><span class="burnin-sub">画面をタップ、または ESC で終了します</span></p>
+                        <button id="exitBurnInBtn" class="burnin-exit">終了する</button>
+                    </div>
                 </div>
 
             </div>

--- a/home/passkey.js
+++ b/home/passkey.js
@@ -16,6 +16,11 @@ function bufferToBase64url(buffer) {
 }
 
 async function handlePasskeyRegistration(usernameParam = null) {
+    if (!window.PublicKeyCredential) {
+        Swal.fire('エラー', 'このブラウザはパスキーに対応していません。', 'error');
+        return;
+    }
+
     const username = usernameParam || document.getElementById("username")?.value.trim() || document.getElementById("registerUsername")?.value.trim();
     if (!username) {
         Swal.fire("エラー", "ユーザー名が必要です", "error");
@@ -55,7 +60,13 @@ async function startRegistration(options, username) {
     options.publicKey.challenge = Uint8Array.from(atob(options.publicKey.challenge), c => c.charCodeAt(0));
     options.publicKey.user.id = Uint8Array.from(atob(options.publicKey.user.id), c => c.charCodeAt(0));
 
-    const credential = await navigator.credentials.create({ publicKey: options.publicKey });
+    let credential;
+    try {
+        credential = await navigator.credentials.create({ publicKey: options.publicKey });
+    } catch (err) {
+        Swal.fire('エラー', err.message || 'パスキーの登録に失敗しました。', 'error');
+        throw err;
+    }
 
     const body = {
         username: username,
@@ -81,6 +92,11 @@ async function startRegistration(options, username) {
 }
 
 async function startLogin(usernameParam = null) {
+    if (!window.PublicKeyCredential) {
+        Swal.fire('エラー', 'このブラウザはパスキーに対応していません。', 'error');
+        return;
+    }
+
     const username = usernameParam || document.getElementById("username")?.value.trim() || document.getElementById("loginUsername")?.value.trim();
     if (!username) {
         Swal.fire("エラー", "ユーザー名が必要です", "error");
@@ -117,7 +133,13 @@ async function startLogin(usernameParam = null) {
         id: Uint8Array.from(atob(cred.id), c => c.charCodeAt(0))
     }));
 
-    const assertion = await navigator.credentials.get({ publicKey: options.publicKey });
+    let assertion;
+    try {
+        assertion = await navigator.credentials.get({ publicKey: options.publicKey });
+    } catch (err) {
+        Swal.fire('エラー', err.message || 'パスキー認証に失敗しました。', 'error');
+        throw err;
+    }
 
     const response = {
         id: assertion.id,

--- a/home/shift_modal.js
+++ b/home/shift_modal.js
@@ -57,7 +57,9 @@ document.addEventListener('DOMContentLoaded', () => {
             }
 
             // カレンダーの再取得
-            if (typeof loadSchedules === 'function') {
+            if (window.calendarManager && typeof window.calendarManager.reloadSchedules === 'function') {
+                await window.calendarManager.reloadSchedules({ keepSelection: true });
+            } else if (typeof loadSchedules === 'function') {
                 await loadSchedules();
             }
 

--- a/home/style.css
+++ b/home/style.css
@@ -125,3 +125,73 @@ body {
     max-height: 50vh; /* 元の挙動に近い高さ管理 */
     overflow-y: auto;
 }
+
+/* Burn-in protection overlay */
+#burnInOverlay {
+    position: fixed;
+    inset: 0;
+    z-index: 90;
+    background: radial-gradient(circle at 20% 20%, rgba(20, 20, 20, 0.95), #000 70%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    cursor: pointer;
+    animation: burnin-drift 20s ease-in-out infinite alternate;
+}
+
+.burnin-content {
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.5rem;
+}
+
+.burnin-pulse {
+    width: 140px;
+    height: 140px;
+    border-radius: 50%;
+    background: radial-gradient(circle, rgba(255,255,255,0.2) 0%, rgba(255,255,255,0) 70%);
+    animation: burnin-pulse 3.2s ease-in-out infinite;
+}
+
+.burnin-text {
+    font-size: 1.25rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-shadow: 0 0 12px rgba(255,255,255,0.35);
+}
+
+.burnin-sub {
+    display: block;
+    margin-top: 0.5rem;
+    font-size: 0.85rem;
+    color: rgba(255,255,255,0.7);
+}
+
+.burnin-exit {
+    padding: 0.6rem 2.4rem;
+    border-radius: 9999px;
+    background: rgba(255,255,255,0.12);
+    border: 1px solid rgba(255,255,255,0.25);
+    color: #fff;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.burnin-exit:hover {
+    background: rgba(255,255,255,0.22);
+    transform: scale(1.05);
+}
+
+@keyframes burnin-pulse {
+    0%, 100% { transform: scale(0.9); opacity: 0.6; }
+    50% { transform: scale(1.05); opacity: 1; }
+}
+
+@keyframes burnin-drift {
+    0% { background-position: 30% 30%; }
+    100% { background-position: 70% 70%; }
+}

--- a/home/subscription.js
+++ b/home/subscription.js
@@ -1,140 +1,49 @@
 // 2025 TabDock: darui3018823 All rights reserved.
 // All works created by darui3018823 associated with this repository are the intellectual property of darui3018823.
 // Packages and other third-party materials used in this repository are subject to their respective licenses and copyrights.
-// This code Version: 5.5.0_subsc-r2
+// This code Version: 5.6.0_subsc-r3
 
 class SubscriptionManager {
     constructor() {
-        this.modal = null;
-        this.form = null;
+        this.modal = document.getElementById('subscriptionModal');
+        this.form = document.getElementById('subscriptionForm');
+        this.paymentMethodSelect = this.form?.querySelector('[name="paymentMethod"]') ?? null;
         this.notificationTimers = new Set();
         this.initialize();
     }
 
     initialize() {
-        this.createModal();
+        if (!this.modal || !this.form) {
+            console.warn('[SubscriptionManager] モーダル要素が見つかりませんでした。');
+            return;
+        }
+
+        this.hideAllPaymentDetails();
         this.setupEventListeners();
     }
 
-    createModal() {
-        const modalHTML = `
-            <div id="subscriptionModal" class="fixed inset-0 bg-black bg-opacity-70 hidden items-center justify-center transition-opacity duration-300">
-                <div class="bg-gray-900 bg-opacity-95 rounded-lg p-6 w-full max-w-md transform scale-95 opacity-0 transition-all duration-300 shadow-2xl border border-gray-800">
-                    <h2 class="text-2xl font-bold mb-4 text-white">サブスクリプションスケジュールを追加</h2>
-                    <form id="subscriptionForm" class="space-y-4">
-                        <div>
-                            <label class="block text-sm font-medium text-gray-200">サービス名</label>
-                            <input type="text" name="serviceName" required class="mt-1 block w-full rounded-md bg-gray-800 text-white border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
-                        </div>
-                        <div>
-                            <label class="block text-sm font-medium text-gray-200">プラン名</label>
-                            <input type="text" name="planName" required class="mt-1 block w-full rounded-md bg-gray-800 text-white border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
-                        </div>
-                        <div class="grid grid-cols-2 gap-4">
-                            <div>
-                                <label class="block text-sm font-medium text-gray-200">金額</label>
-                                <input type="number" name="amount" required class="mt-1 block w-full rounded-md bg-gray-800 text-white border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
-                            </div>
-                            <div>
-                                <label class="block text-sm font-medium text-gray-200">通貨</label>
-                                <select name="currency" required class="mt-1 block w-full rounded-md bg-gray-800 text-white border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
-                                    <option value="" selected disabled>選択してください</option>
-                                    <option value="JPY">JPY</option>
-                                    <option value="USD">USD</option>
-                                    <option value="EUR">EUR</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div>
-                            <label class="block text-sm font-medium text-gray-200">課金サイクル</label>
-                            <select name="billingCycle" required class="mt-1 block w-full rounded-md bg-gray-800 text-white border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
-                                <option value="" selected disabled>選択してください</option>
-                                <option value="monthly">月額</option>
-                                <option value="yearly">年額</option>
-                            </select>
-                        </div>
-                        <div>
-                            <label class="block text-sm font-medium text-gray-200">決済方法</label>
-                            <select name="paymentMethod" required class="mt-1 block w-full rounded-md bg-gray-800 text-white border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
-                                <option value="" selected disabled>選択してください</option>
-                                <option value="CC">クレジットカード</option>
-                                <option value="PayPal">PayPal</option>
-                                <option value="GooglePay">Google Pay</option>
-                                <option value="ApplePay">Apple Pay</option>
-                                <option value="PayPay">PayPay</option>
-                                <option value="AmazonPay">Amazon Pay</option>
-                                <option value="Other">その他</option>
-                            </select>
-                        </div>
-                        <div id="paymentDetails" class="hidden space-y-4">
-                            <div id="ccDetails" class="hidden">
-                                <label class="block text-sm font-medium text-gray-200">カード末尾4桁（任意）</label>
-                                <input type="text" name="cardLastFour" pattern="[0-9]{4}" maxlength="4" class="mt-1 block w-full rounded-md bg-gray-800 text-white border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
-                            </div>
-                            <div id="paypalDetails" class="hidden">
-                                <label class="block text-sm font-medium text-gray-200">PayPalメールアドレス（任意）</label>
-                                <input type="email" name="paypalEmail" class="mt-1 block w-full rounded-md bg-gray-800 text-white border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
-                            </div>
-                            <div id="otherDetails" class="hidden">
-                                <div>
-                                    <label class="block text-sm font-medium text-gray-200">決済方法名</label>
-                                    <input type="text" name="otherPaymentMethod" class="mt-1 block w-full rounded-md bg-gray-800 text-white border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
-                                </div>
-                                <div>
-                                    <label class="block text-sm font-medium text-gray-200">ラベル（任意）</label>
-                                    <input type="text" name="otherPaymentLabel" class="mt-1 block w-full rounded-md bg-gray-800 text-white border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
-                                </div>
-                            </div>
-                        </div>
-                        <div>
-                            <label class="block text-sm font-medium text-gray-200">次回支払日</label>
-                            <input type="date" name="nextPaymentDate" required class="mt-1 block w-full rounded-md bg-gray-800 text-white border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
-                        </div>
-                        <div class="flex justify-end space-x-3 pt-4">
-                            <button type="button" id="cancelSubscription" class="px-4 py-2 bg-gray-700 text-white rounded-md hover:bg-gray-600 transition-colors">
-                                キャンセル
-                            </button>
-                            <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition-colors">
-                                保存
-                            </button>
-                        </div>
-                    </form>
-                </div>
-            </div>
-        `;
-
-        document.body.insertAdjacentHTML('beforeend', modalHTML);
-        this.modal = document.getElementById('subscriptionModal');
-        this.form = document.getElementById('subscriptionForm');
-    }
-
     setupEventListeners() {
-            document.addEventListener('DOMContentLoaded', () => {
-                const addButton = document.querySelector('[data-action="add-subscription"]');
-                if (addButton) {
-                    addButton.addEventListener('click', () => {
-                        const scheduleTypeModal = document.getElementById('scheduleTypeModal');
-                        if (scheduleTypeModal) {
-                            scheduleTypeModal.classList.add('hidden');
-                            scheduleTypeModal.classList.remove('flex');
-                        }
-                        this.showModal();
-                    });
-                }
-            });
-
-        const paymentMethodSelect = this.form.querySelector('[name="paymentMethod"]');
-        paymentMethodSelect.addEventListener('change', (e) => this.handlePaymentMethodChange(e));
-
-        this.form.addEventListener('submit', (e) => this.handleSubmit(e));
-        document.getElementById('cancelSubscription').addEventListener('click', () => {
-            // scheduleTypeModalを閉じる
-            const scheduleTypeModal = document.getElementById('scheduleTypeModal');
-            if (scheduleTypeModal) {
-                scheduleTypeModal.classList.add('hidden');
-                scheduleTypeModal.classList.remove('flex');
+        const registerAddButton = () => {
+            const addButton = document.querySelector('[data-action="add-subscription"]');
+            if (addButton) {
+                addButton.addEventListener('click', () => this.showAddModal());
             }
+        };
+
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', registerAddButton, { once: true });
+        } else {
+            registerAddButton();
+        }
+
+        this.paymentMethodSelect?.addEventListener('change', (e) => this.handlePaymentMethodChange(e));
+        this.form.addEventListener('submit', (e) => this.handleSubmit(e));
+
+        const cancelBtn = document.getElementById('cancelSubscription');
+        cancelBtn?.addEventListener('click', () => {
             this.hideModal();
+            const scheduleTypeModal = document.getElementById('scheduleTypeModal');
+            scheduleTypeModal?.classList.add('hidden');
         });
 
         this.modal.addEventListener('click', (e) => {
@@ -142,44 +51,41 @@ class SubscriptionManager {
                 this.hideModal();
             }
         });
+
+        window.addEventListener('subscription:request-open', () => this.showAddModal());
+    }
+
+    showAddModal() {
+        const scheduleTypeModal = document.getElementById('scheduleTypeModal');
+        if (scheduleTypeModal) {
+            scheduleTypeModal.classList.add('hidden');
+        }
+        this.showModal();
     }
 
     showModal() {
+        if (!this.modal) return;
         this.modal.classList.remove('hidden');
-        this.modal.classList.add('flex');
-        this.modal.style.zIndex = '1000';
-        requestAnimationFrame(() => {
-            const modalContent = this.modal.querySelector('.bg-gray-900');
-            if (modalContent) {
-                modalContent.classList.remove('scale-95', 'opacity-0');
-                modalContent.classList.add('scale-100', 'opacity-100');
-            }
-        });
+        const firstInput = this.form?.querySelector('input[name="serviceName"]');
+        firstInput?.focus();
     }
 
     hideModal() {
-        const modalContent = this.modal.querySelector('.bg-gray-900');
-        if (modalContent) {
-            modalContent.classList.remove('scale-100', 'opacity-100');
-            modalContent.classList.add('scale-95', 'opacity-0');
-
-        }
-        setTimeout(() => {
-            this.modal.classList.remove('flex');
-            this.modal.classList.add('hidden');
-            this.form.reset();
-            this.hideAllPaymentDetails();
-        }, 300);
+        if (!this.modal) return;
+        this.modal.classList.add('hidden');
+        this.form?.reset();
+        this.hideAllPaymentDetails();
     }
 
-    handlePaymentMethodChange(e) {
+    handlePaymentMethodChange(event) {
         this.hideAllPaymentDetails();
+        const method = event.target.value;
         const paymentDetails = document.getElementById('paymentDetails');
-        const method = e.target.value;
+        if (!paymentDetails) return;
 
         if (method === 'CC') {
             paymentDetails.classList.remove('hidden');
-            document.getElementById('ccDetails').classList.remove('hidden');
+            document.getElementById('ccDetails')?.classList.remove('hidden');
             Swal.fire({
                 title: '注意',
                 text: 'セキュリティ上の理由により、カード情報の全てを入力することはできません。末尾4桁のみ任意で記録できます。',
@@ -188,26 +94,41 @@ class SubscriptionManager {
             });
         } else if (method === 'PayPal') {
             paymentDetails.classList.remove('hidden');
-            document.getElementById('paypalDetails').classList.remove('hidden');
+            document.getElementById('paypalDetails')?.classList.remove('hidden');
         } else if (method === 'Other') {
             paymentDetails.classList.remove('hidden');
-            document.getElementById('otherDetails').classList.remove('hidden');
+            document.getElementById('otherDetails')?.classList.remove('hidden');
         }
     }
 
     hideAllPaymentDetails() {
-        const details = ['ccDetails', 'paypalDetails', 'otherDetails'];
-        document.getElementById('paymentDetails').classList.add('hidden');
-        details.forEach(id => document.getElementById(id).classList.add('hidden'));
+        const paymentDetails = document.getElementById('paymentDetails');
+        paymentDetails?.classList.add('hidden');
+        ['ccDetails', 'paypalDetails', 'otherDetails'].forEach((id) => {
+            document.getElementById(id)?.classList.add('hidden');
+        });
     }
 
-    async handleSubmit(e) {
-        e.preventDefault();
+    async handleSubmit(event) {
+        event.preventDefault();
+        if (!this.form) return;
+
         const formData = new FormData(this.form);
-        const data = {
+        const amount = Number(formData.get('amount'));
+        if (Number.isNaN(amount) || amount < 0) {
+            Swal.fire({
+                title: '入力エラー',
+                text: '金額は0以上の数値を入力してください。',
+                icon: 'warning',
+                confirmButtonText: 'OK'
+            });
+            return;
+        }
+
+        const payload = {
             serviceName: formData.get('serviceName'),
             planName: formData.get('planName'),
-            amount: Number(formData.get('amount')),
+            amount,
             currency: formData.get('currency'),
             billingCycle: formData.get('billingCycle'),
             paymentMethod: formData.get('paymentMethod'),
@@ -215,33 +136,42 @@ class SubscriptionManager {
             paymentDetails: {}
         };
 
-        switch (data.paymentMethod) {
+        switch (payload.paymentMethod) {
             case 'CC':
                 if (formData.get('cardLastFour')) {
-                    data.paymentDetails.cardLastFour = formData.get('cardLastFour');
+                    payload.paymentDetails.cardLastFour = formData.get('cardLastFour');
                 }
                 break;
             case 'PayPal':
                 if (formData.get('paypalEmail')) {
-                    data.paymentDetails.paypalEmail = formData.get('paypalEmail');
+                    payload.paymentDetails.paypalEmail = formData.get('paypalEmail');
                 }
                 break;
             case 'Other':
-                data.paymentDetails.methodName = formData.get('otherPaymentMethod');
-                if (formData.get('otherPaymentLabel')) {
-                    data.paymentDetails.label = formData.get('otherPaymentLabel');
+                if (formData.get('otherPaymentMethod')) {
+                    payload.paymentDetails.methodName = formData.get('otherPaymentMethod');
                 }
+                if (formData.get('otherPaymentLabel')) {
+                    payload.paymentDetails.label = formData.get('otherPaymentLabel');
+                }
+                break;
+            default:
                 break;
         }
 
         try {
             let username = null;
-            if (window.getLoggedInUser) {
+            if (typeof window.getLoggedInUser === 'function') {
                 const user = window.getLoggedInUser();
-                if (user && user.username) username = user.username;
-            } else if (localStorage.getItem('tabdock_user')) {
+                if (user?.username) {
+                    username = user.username;
+                }
+            }
+            if (!username && localStorage.getItem('tabdock_user')) {
                 const user = JSON.parse(localStorage.getItem('tabdock_user'));
-                if (user && user.username) username = user.username;
+                if (user?.username) {
+                    username = user.username;
+                }
             }
 
             if (!username) {
@@ -254,13 +184,16 @@ class SubscriptionManager {
                     'Content-Type': 'application/json',
                     'X-Username': encodeURIComponent(username)
                 },
-                body: JSON.stringify(data),
+                body: JSON.stringify(payload),
                 credentials: 'include'
             });
 
             if (!response.ok) {
-                throw new Error('サーバーエラーが発生しました');
+                const message = await response.text();
+                throw new Error(message || 'サーバーエラーが発生しました');
             }
+
+            const saved = await response.json().catch(() => null);
 
             await Swal.fire({
                 title: '成功',
@@ -270,12 +203,18 @@ class SubscriptionManager {
             });
 
             this.hideModal();
-            if (window.calendarManager) {
-                window.calendarManager.refreshCalendar();
+
+            const detail = {
+                action: 'created',
+                subscription: saved || payload
+            };
+            window.dispatchEvent(new CustomEvent('subscription:data-changed', { detail }));
+
+            if (window.calendarManager?.refreshCalendar) {
+                window.calendarManager.refreshCalendar({ keepSelection: true, forceReload: true }).catch(() => {});
             }
-            if (window.accountManager) {
-                window.accountManager.refreshSubscriptions();
-            }
+
+            await this.scheduleNotifications().catch(() => {});
         } catch (error) {
             Swal.fire({
                 title: 'エラー',
@@ -298,13 +237,13 @@ class SubscriptionManager {
         this.clearNotificationTimers();
         try {
             let username = null;
-            if (window.getLoggedInUser) {
+            if (typeof window.getLoggedInUser === 'function') {
                 const user = window.getLoggedInUser();
-                if (user && user.username) username = user.username;
+                if (user?.username) username = user.username;
             }
             if (!username && localStorage.getItem('tabdock_user')) {
                 const user = JSON.parse(localStorage.getItem('tabdock_user'));
-                if (user && user.username) username = user.username;
+                if (user?.username) username = user.username;
             }
 
             if (!username) {
@@ -316,10 +255,10 @@ class SubscriptionManager {
                 credentials: 'include'
             });
             if (!response.ok) throw new Error('通知の取得に失敗しました');
-            
+
             const subscriptions = await response.json();
-            
-            subscriptions.forEach(sub => {
+
+            subscriptions.forEach((sub) => {
                 const paymentDate = new Date(sub.nextPaymentDate);
                 if (Number.isNaN(paymentDate.getTime())) {
                     return;
@@ -335,13 +274,13 @@ class SubscriptionManager {
                     const timeout = setTimeout(() => {
                         Swal.fire({
                             title: 'サブスクリプション支払い予定',
-                            html: `<p>${sub.serviceName}の支払いが3日後に予定されています。</p>
-                                  <p>金額: ${sub.amount} ${sub.currency}</p>`,
+                            html: `<p>${sub.serviceName}の支払いが3日後に予定されています。</p>` +
+                                  `<p>金額: ${sub.amount} ${sub.currency}</p>`,
                             icon: 'info',
                             confirmButtonText: '了解'
                         });
                         this.notificationTimers.delete(timeout);
-                    }, threeDaysBefore - now);
+                    }, threeDaysBefore.getTime() - now.getTime());
                     this.notificationTimers.add(timeout);
                 }
 
@@ -349,13 +288,13 @@ class SubscriptionManager {
                     const timeout = setTimeout(() => {
                         Swal.fire({
                             title: 'サブスクリプション支払い予定',
-                            html: `<p>${sub.serviceName}の支払いが明日予定されています。</p>
-                                  <p>金額: ${sub.amount} ${sub.currency}</p>`,
+                            html: `<p>${sub.serviceName}の支払いが明日予定されています。</p>` +
+                                  `<p>金額: ${sub.amount} ${sub.currency}</p>`,
                             icon: 'warning',
                             confirmButtonText: '了解'
                         });
                         this.notificationTimers.delete(timeout);
-                    }, oneDayBefore - now);
+                    }, oneDayBefore.getTime() - now.getTime());
                     this.notificationTimers.add(timeout);
                 }
             });

--- a/home/weather.js
+++ b/home/weather.js
@@ -207,7 +207,20 @@ function showDetail(key, label, detail, overview) {
     const rainHtml = Object.entries(rain)
         .map(([time, percent]) => {
             const label = time.replace("T", "").replace("_", "–");
-            return `<div class="inline-block mr-4">${label}時: ${percent}</div>`;
+            const numeric = parseInt(String(percent || '').replace('%', ''), 10);
+            const safeValue = Number.isFinite(numeric) ? Math.max(0, Math.min(100, numeric)) : 0;
+            const intensityClass = safeValue >= 70 ? 'bg-red-500' : safeValue >= 40 ? 'bg-yellow-400' : 'bg-blue-400';
+            const textClass = safeValue >= 70 ? 'text-red-200' : safeValue >= 40 ? 'text-yellow-200' : 'text-blue-200';
+
+            return `
+                <div class="flex items-center gap-3">
+                    <div class="w-20 text-xs text-white/80">${label}時</div>
+                    <div class="flex-1 bg-white/10 rounded-full h-2 overflow-hidden">
+                        <div class="h-full ${intensityClass}" style="width:${safeValue}%"></div>
+                    </div>
+                    <div class="w-12 text-xs text-right ${textClass}">${percent || '--%'}</div>
+                </div>
+            `;
         }).join("");
 
     modalTitle.textContent = `${label} の天気の詳細`;
@@ -215,7 +228,10 @@ function showDetail(key, label, detail, overview) {
         <p><strong>天気:</strong> ${detail.weather}</p>
         <p><strong>風:</strong> ${detail.wind}</p>
         <p><strong>波:</strong> ${detail.wave}</p>
-        <p><strong>降水確率:</strong><br>${rainHtml}</p>
+        <div class="mt-2">
+            <div class="font-semibold text-sm mb-1">降水確率</div>
+            <div class="space-y-1">${rainHtml}</div>
+        </div>
         <hr class="my-2 border-gray-600" />
         <p><strong>概況:</strong><br>${overview || "情報なし"}</p>
     `;


### PR DESCRIPTION
## Summary
- add a static subscription creation modal with a rebuilt front-end manager that refreshes calendars and schedules notifications automatically
- extend the calendar, account, and devtools flows to react to subscription events, filter shift data by the logged-in user, and expose burn-in protection controls
- improve precipitation visibility, harden passkey and shift handlers, and collect system status concurrently with goroutines

## Testing
- go test ./... *(hangs locally; aborted with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_68f4b861978c832aaae2e2d9f1514c3d