### PR TITLE
Add ICS import support to schedule modal

### DIFF
--- a/home/index.html
+++ b/home/index.html
@@ -314,6 +314,14 @@
                 <input type="text" id="scheduleTitle" placeholder="タイトル" class="w-full p-2 rounded bg-gray-700 text-white mb-2" required>
                 <input type="text" id="scheduleTime" class="hidden" aria-hidden="true">
 
+                <div class="mb-3">
+                    <label class="block text-sm mb-1">ICSファイルから読み込む</label>
+                    <input type="file" id="scheduleIcsFile" accept=".ics,text/calendar"
+                        class="text-white file:bg-gray-600 file:text-white file:rounded file:px-2 file:py-1" />
+                    <p class="text-xs text-white/60 mt-1">ICSファイルの内容をもとに日付や時間などを自動入力します。</p>
+                    <div id="scheduleIcsInfo" class="text-xs text-white/70 mt-1"></div>
+                </div>
+
                 <button id="regularToggleDetail" class="text-sm text-blue-400 hover:underline mb-2">▼ 詳細設定を表示</button>
 
                 <div id="regularDetailSection" class="hidden">


### PR DESCRIPTION
## Summary
- add an ICS upload control to the regular schedule modal and surface parsed details to users
- parse ICS files on the client to populate date, time, title, location, and notes automatically

## Testing
- go test ./... *(interrupted: command was stopped after hanging while downloading modules)*

------
https://chatgpt.com/codex/tasks/task_e_68fdbc75724c832ab8528d291e16d84c