### PR TITLE
Improve devtools UX, account password management, and backend caching

### DIFF
--- a/getstatus/getstatus_main_win.go
+++ b/getstatus/getstatus_main_win.go
@@ -8,6 +8,7 @@ package getstatus
 
 import (
 	"fmt"
+	"log"
 	"net"
 	"os"
 	"strings"
@@ -125,10 +126,19 @@ func getMem() string {
 }
 
 func getDriveC() string {
-        d, _ := disk.Usage("C:\\")
-        const gib = 1024 * 1024 * 1024
-        return fmt.Sprintf("%.0f%% (%.1fGiB/%.1fGiB)",
-                d.UsedPercent, float64(d.Used)/float64(gib), float64(d.Total)/float64(gib))
+	usage, err := disk.Usage("C:\\")
+	if err != nil {
+		log.Printf("failed to query drive C usage: %v", err)
+		return "N/A"
+	}
+	if usage == nil {
+		log.Printf("drive C usage result is nil")
+		return "N/A"
+	}
+
+	const gib = 1024 * 1024 * 1024
+	return fmt.Sprintf("%.0f%% (%.1fGiB/%.1fGiB)",
+		usage.UsedPercent, float64(usage.Used)/float64(gib), float64(usage.Total)/float64(gib))
 }
 
 func getUptime() string {

--- a/getstatus/getstatus_main_win.go
+++ b/getstatus/getstatus_main_win.go
@@ -125,9 +125,10 @@ func getMem() string {
 }
 
 func getDriveC() string {
-	d, _ := disk.Usage("C:\\")
-	return fmt.Sprintf("%.0f%% (%.0fGB/%.0fGB)",
-		d.UsedPercent, float64(d.Used)/1e9, float64(d.Total)/1e9)
+        d, _ := disk.Usage("C:\\")
+        const gib = 1024 * 1024 * 1024
+        return fmt.Sprintf("%.0f%% (%.1fGiB/%.1fGiB)",
+                d.UsedPercent, float64(d.Used)/float64(gib), float64(d.Total)/float64(gib))
 }
 
 func getUptime() string {

--- a/home/account.js
+++ b/home/account.js
@@ -767,9 +767,11 @@ async function handlePasswordChangeSubmit(event) {
     try {
         const response = await fetch("/api/auth/change-password", {
             method: "POST",
-            headers: { "Content-Type": "application/json" },
+            headers: {
+                "Content-Type": "application/json",
+                "X-Username": encodeURIComponent(user.username)
+            },
             body: JSON.stringify({
-                username: user.username,
                 currentPassword,
                 newPassword
             })

--- a/home/index.html
+++ b/home/index.html
@@ -755,57 +755,94 @@
                     <div class="td-modal-panel td-modal-lg">
                         <h2 class="text-xl font-bold mb-4">開発者向けメニュー</h2>
 
-                        <div class="space-y-4 text-sm font-mono">
-                            <div class="flex justify-between">
-                                <span>完全同期（サーバーから全データ再取得）</span>
-                                <button id="forceSyncBtn" class="bg-green-600 hover:bg-green-500 px-3 py-1 rounded">同期する</button>
+                        <div class="space-y-6 text-sm">
+                            <div>
+                                <h3 class="text-xs font-semibold uppercase tracking-widest text-white/60 mb-2">同期・診断</h3>
+                                <div class="space-y-3 bg-black/25 rounded-lg p-4">
+                                    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                                        <div>
+                                            <p class="font-semibold">完全同期</p>
+                                            <p class="text-xs text-white/60">サーバーから主要データを再取得し、ウィジェットを更新します</p>
+                                        </div>
+                                        <button id="forceSyncBtn" class="bg-green-600 hover:bg-green-500 px-4 py-1.5 rounded">同期する</button>
+                                    </div>
+                                    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                                        <div>
+                                            <p class="font-semibold">JavaScriptロード状態確認</p>
+                                            <p class="text-xs text-white/60">主要スクリプトの読込状況と関数の有無をチェックします</p>
+                                        </div>
+                                        <button id="checkJsStatusBtn" class="bg-blue-600 hover:bg-blue-500 px-4 py-1.5 rounded">確認</button>
+                                    </div>
+                                    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                                        <div>
+                                            <p class="font-semibold">簡易診断</p>
+                                            <p class="text-xs text-white/60">UI・API・ブラウザ環境をまとめて検証します</p>
+                                        </div>
+                                        <button id="quickDiagBtn" class="bg-cyan-600 hover:bg-cyan-500 px-4 py-1.5 rounded">診断</button>
+                                    </div>
+                                    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                                        <div>
+                                            <p class="font-semibold">パフォーマンステスト</p>
+                                            <p class="text-xs text-white/60">DOM生成やネットワーク応答時間を計測します</p>
+                                        </div>
+                                        <button id="runPerfTestBtn" class="bg-orange-600 hover:bg-orange-500 px-4 py-1.5 rounded">実行</button>
+                                    </div>
+                                </div>
                             </div>
 
-                            <div class="flex justify-between">
-                                <span>カレンダーを再生成</span>
-                                <button id="regenerateCalendarBtn" class="bg-indigo-600 hover:bg-indigo-500 px-3 py-1 rounded">再生成</button>
+                            <div>
+                                <h3 class="text-xs font-semibold uppercase tracking-widest text-white/60 mb-2">メンテナンス</h3>
+                                <div class="space-y-3 bg-black/25 rounded-lg p-4">
+                                    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                                        <div>
+                                            <p class="font-semibold">カレンダー再生成</p>
+                                            <p class="text-xs text-white/60">祝日・予定・サブスクリプションを再描画します</p>
+                                        </div>
+                                        <button id="regenerateCalendarBtn" class="bg-indigo-600 hover:bg-indigo-500 px-4 py-1.5 rounded">再生成</button>
+                                    </div>
+                                    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                                        <div>
+                                            <p class="font-semibold">ローカルストレージ初期化</p>
+                                            <p class="text-xs text-white/60">保存済みの設定やキャッシュを削除します</p>
+                                        </div>
+                                        <button id="clearLocalStorageBtn" class="bg-red-600 hover:bg-red-500 px-4 py-1.5 rounded">クリア</button>
+                                    </div>
+                                    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                                        <div>
+                                            <p class="font-semibold">デバッグログ表示</p>
+                                            <p class="text-xs text-white/60">最新ログと環境情報を確認・エクスポートします</p>
+                                        </div>
+                                        <button id="showDebugLogBtn" class="bg-purple-600 hover:bg-purple-500 px-4 py-1.5 rounded">表示</button>
+                                    </div>
+                                    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                                        <div>
+                                            <p class="font-semibold">画面焼け防止モード</p>
+                                            <p class="text-xs text-white/60">インタラクションが無い間は暗転させます</p>
+                                        </div>
+                                        <button id="toggleBurnInProtectionBtn" class="bg-slate-600 hover:bg-slate-500 px-4 py-1.5 rounded">起動</button>
+                                    </div>
+                                </div>
                             </div>
 
-                            <div class="flex justify-between">
-                                <span>JavaScriptロード状態確認</span>
-                                <button id="checkJsStatusBtn" class="bg-blue-600 hover:bg-blue-500 px-3 py-1 rounded">確認</button>
+                            <div>
+                                <h3 class="text-xs font-semibold uppercase tracking-widest text-white/60 mb-2">その他ツール</h3>
+                                <div class="space-y-3 bg-black/25 rounded-lg p-4">
+                                    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                                        <div>
+                                            <p class="font-semibold">ログインユーザーのシフト削除</p>
+                                            <p class="text-xs text-white/60">サーバー上の個人シフトを一括削除します</p>
+                                        </div>
+                                        <button id="deleteAllShiftsBtn" class="bg-red-600 hover:bg-red-500 px-4 py-1.5 rounded">削除</button>
+                                    </div>
+                                    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                                        <div>
+                                            <p class="font-semibold">ページ再読み込み</p>
+                                            <p class="text-xs text-white/60">最新の構成に更新します（保存されていない変更は失われます）</p>
+                                        </div>
+                                        <button id="reloadPageBtn" class="bg-gray-600 hover:bg-gray-500 px-4 py-1.5 rounded">再読込</button>
+                                    </div>
+                                </div>
                             </div>
-
-                            <div class="flex justify-between">
-                                <span>簡易診断実行</span>
-                                <button id="quickDiagBtn" class="bg-cyan-600 hover:bg-cyan-500 px-3 py-1 rounded">診断</button>
-                            </div>
-
-                            <div class="flex justify-between">
-                                <span>ローカルストレージ初期化</span>
-                                <button id="clearLocalStorageBtn" class="bg-red-600 hover:bg-red-500 px-3 py-1 rounded">クリア</button>
-                            </div>
-
-                            <div class="flex justify-between">
-                                <span>デバッグログ表示</span>
-                                <button id="showDebugLogBtn" class="bg-purple-600 hover:bg-purple-500 px-3 py-1 rounded">表示</button>
-                            </div>
-
-                            <div class="flex justify-between">
-                                <span>パフォーマンステスト実行</span>
-                                <button id="runPerfTestBtn" class="bg-orange-600 hover:bg-orange-500 px-3 py-1 rounded">実行</button>
-                            </div>
-
-                            <div class="flex justify-between">
-                                <span>ログインユーザーのシフトを全て削除</span>
-                                <button id="deleteAllShiftsBtn" class="bg-red-600 hover:bg-red-500 px-3 py-1 rounded">削除</button>
-                            </div>
-
-                            <div class="flex justify-between">
-                                <span>画面焼け防止モード</span>
-                                <button id="toggleBurnInProtectionBtn" class="bg-slate-600 hover:bg-slate-500 px-3 py-1 rounded">起動</button>
-                            </div>
-
-                            <div class="flex justify-between">
-                                <span>ページ再読み込み</span>
-                                <button id="reloadPageBtn" class="bg-gray-600 hover:bg-gray-500 px-3 py-1 rounded">再読込</button>
-                            </div>
-
                         </div>
 
                         <div class="flex justify-end mt-6">

--- a/home/style.css
+++ b/home/style.css
@@ -142,7 +142,7 @@ body {
     position: fixed;
     inset: 0;
     z-index: 90;
-    background: radial-gradient(circle at 20% 20%, rgba(20, 20, 20, 0.95), #000 70%);
+    background: radial-gradient(circle at 50% 50%, rgba(16, 16, 16, 0.95), #000 75%);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -157,6 +157,7 @@ body {
     flex-direction: column;
     align-items: center;
     gap: 1.5rem;
+    transition: opacity 0.3s ease;
 }
 
 .burnin-pulse {
@@ -195,6 +196,16 @@ body {
 .burnin-exit:hover {
     background: rgba(255,255,255,0.22);
     transform: scale(1.05);
+}
+
+#burnInOverlay.sleeping {
+    background: #000;
+    animation: none;
+}
+
+#burnInOverlay.sleeping .burnin-content {
+    opacity: 0;
+    pointer-events: none;
 }
 
 @keyframes burnin-pulse {

--- a/home/subscription.js
+++ b/home/subscription.js
@@ -339,7 +339,7 @@ class SubscriptionManager {
                 window.calendarManager.refreshCalendar({ keepSelection: true, forceReload: true }).catch(() => {});
             }
 
-            await this.scheduleNotifications().catch(() => {});
+            await this.scheduleNotifications({ reschedule: true, immediate: true }).catch(() => {});
         } catch (error) {
             Swal.fire({
                 title: 'エラー',

--- a/home/subscription_calendar.js
+++ b/home/subscription_calendar.js
@@ -319,7 +319,7 @@ class SubscriptionCalendarManager {
 
         const subscriptionListModal = document.createElement('div');
         subscriptionListModal.id = 'subscriptionListModal';
-    subscriptionListModal.className = 'td-modal-overlay z-[70]';
+        subscriptionListModal.className = 'td-modal-overlay z-[70]';
         subscriptionListModal.innerHTML = modalHtml;
 
         document.body.appendChild(subscriptionListModal);
@@ -348,11 +348,12 @@ class SubscriptionCalendarManager {
             document.body.removeChild(subscriptionListModal);
         });
 
-                document.getElementById('addNewSubscription').addEventListener('click', () => {
-                    document.body.removeChild(subscriptionListModal);
-                    const subscriptionManager = window.subscriptionManager;
-                    if (subscriptionManager) {
-                        subscriptionManager.showAddModal();
+        const addButton = document.getElementById('addNewSubscription');
+        addButton?.addEventListener('click', () => {
+            document.body.removeChild(subscriptionListModal);
+            const subscriptionManager = window.subscriptionManager;
+            if (subscriptionManager) {
+                subscriptionManager.showAddModal();
             }
         });
 
@@ -1124,7 +1125,7 @@ class SubscriptionCalendarManager {
                 }
 
                 if (window.subscriptionManager && typeof window.subscriptionManager.scheduleNotifications === 'function') {
-                    await window.subscriptionManager.scheduleNotifications();
+                    await window.subscriptionManager.scheduleNotifications({ reschedule: true });
                 }
             } catch (error) {
                 Swal.fire('エラー', error.message, 'error');
@@ -1244,7 +1245,7 @@ class SubscriptionCalendarManager {
             }
 
             if (updatedAny && window.subscriptionManager && typeof window.subscriptionManager.scheduleNotifications === 'function') {
-                await window.subscriptionManager.scheduleNotifications();
+                await window.subscriptionManager.scheduleNotifications({ reschedule: true });
             }
         } catch (error) {
             console.error('支払い日自動更新処理でエラー:', error);

--- a/main.go
+++ b/main.go
@@ -5,21 +5,23 @@
 package main
 
 import (
-	"bytes"
-	"database/sql"
-	"encoding/json"
-	"fmt"
-	"io"
-	"log"
-	"net/http"
-	"net/url"
-	"os"
-	"path/filepath"
-	"strings"
-	"sync"
-	"tabdock/getstatus"
-	"tabdock/subscription"
-	"time"
+        "bytes"
+        "database/sql"
+        "encoding/json"
+        "errors"
+        "fmt"
+        "io"
+        "log"
+        "net/http"
+        "net/url"
+        "os"
+        "path/filepath"
+        "strconv"
+        "strings"
+        "sync"
+        "tabdock/getstatus"
+        "tabdock/subscription"
+        "time"
 
 	_ "modernc.org/sqlite"
 
@@ -33,14 +35,39 @@ const version = "5.8.1"
 var fallbackHolidays map[string]string
 
 var (
-	schedulePath  = "./json/schedule.json"
-	calendarDir   = "./home/assets/calendar"
-	forbiddenExts = map[string]bool{
-		".htaccess": true, ".php": true, ".asp": true, ".aspx": true,
-		".bat": true, ".cmd": true, ".exe": true, ".sh": true, ".dll": true,
-	}
-	mutex sync.Mutex
+        schedulePath  = "./json/schedule.json"
+        calendarDir   = "./home/assets/calendar"
+        forbiddenExts = map[string]bool{
+                ".htaccess": true, ".php": true, ".asp": true, ".aspx": true,
+                ".bat": true, ".cmd": true, ".exe": true, ".sh": true, ".dll": true,
+        }
+        mutex sync.Mutex
 )
+
+var (
+        weatherCache   = map[string]*cachedWeather{}
+        weatherCacheMu sync.Mutex
+)
+
+type cachedWeather struct {
+        rawResponse map[string]interface{}
+        updatedAt   time.Time
+}
+
+type weatherRequest struct {
+        Data struct {
+                PrefName string `json:"prefname"`
+                CityName string `json:"cityname"`
+        } `json:"data"`
+}
+
+type weatherBody struct {
+        MainData interface{} `json:"main_data"`
+}
+
+type weatherAPIResponse struct {
+        Body weatherBody `json:"body"`
+}
 
 // type
 type responseWriterWithStatus struct {
@@ -169,9 +196,10 @@ func main() {
 	mux.HandleFunc("/api/upload-profile-image", secureHandler(handleProfileImageUpload))
 
 	// Authentication APIs
-	mux.HandleFunc("/api/auth/login", secureHandler(handleAuthLogin))
-	mux.HandleFunc("/api/auth/register", secureHandler(handleAuthRegister))
-	mux.HandleFunc("/api/auth/user-info", secureHandler(handleUserInfo))
+        mux.HandleFunc("/api/auth/login", secureHandler(handleAuthLogin))
+        mux.HandleFunc("/api/auth/register", secureHandler(handleAuthRegister))
+        mux.HandleFunc("/api/auth/user-info", secureHandler(handleUserInfo))
+        mux.HandleFunc("/api/auth/change-password", secureHandler(handleAuthChangePassword))
 
 	// Subscription APIs
 	subscriptionDB, err := sql.Open("sqlite", "./database/subscription.db")
@@ -182,9 +210,10 @@ func main() {
 	mux.HandleFunc("/api/subscriptions", secureHandler(subHandler.Create))
 	mux.HandleFunc("/api/subscriptions/list", secureHandler(subHandler.GetUserSubscriptions))
 	mux.HandleFunc("/api/subscriptions/upcoming", secureHandler(subHandler.GetUpcoming))
-	mux.HandleFunc("/api/subscriptions/update", secureHandler(subHandler.Update))
-	mux.HandleFunc("/api/subscriptions/status", secureHandler(subHandler.UpdateStatus))
-	mux.HandleFunc("/api/subscriptions/delete", secureHandler(subHandler.Delete))
+        mux.HandleFunc("/api/subscriptions/update", secureHandler(subHandler.Update))
+        mux.HandleFunc("/api/subscriptions/status", secureHandler(subHandler.UpdateStatus))
+        mux.HandleFunc("/api/subscriptions/delete", secureHandler(subHandler.Delete))
+        mux.HandleFunc("/api/pwa-status", secureHandler(handlePWAStatus))
 
 	// WebAuthn
 	mux.HandleFunc("/api/webauthn/register/start", secureHandler(HandleWebAuthnRegisterStart))
@@ -393,39 +422,352 @@ func getPCStatus() (*getstatus.PCStatus, error) {
 }
 
 func handleWeather(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
+        w.Header().Set("Content-Type", "application/json")
 
-	// HEADリクエストならOKのみ返す
-	if r.Method == http.MethodHead {
-		w.WriteHeader(http.StatusOK)
-		return
-	}
+        // HEADリクエストならOKのみ返す
+        if r.Method == http.MethodHead {
+                w.WriteHeader(http.StatusOK)
+                return
+        }
 
-	// クライアントからのリクエストボディを読み取る
-	reqBody, err := io.ReadAll(r.Body)
-	if err != nil {
-		http.Error(w, "failed to read request", http.StatusBadRequest)
-		return
-	}
+        // クライアントからのリクエストボディを読み取る
+        reqBody, err := io.ReadAll(r.Body)
+        if err != nil {
+                http.Error(w, "failed to read request", http.StatusBadRequest)
+                return
+        }
 
-	// APIにリクエストを転送
-	resp, err := http.Post("https://api.daruks.com/weather", "application/json", bytes.NewBuffer(reqBody))
-	if err != nil {
-		http.Error(w, "failed to call weather API", http.StatusInternalServerError)
-		log.Println("weather API error:", err)
+        var wReq weatherRequest
+        regionKey := ""
+        if err := json.Unmarshal(reqBody, &wReq); err == nil {
+                pref := strings.TrimSpace(wReq.Data.PrefName)
+                city := strings.TrimSpace(wReq.Data.CityName)
+                if pref != "" || city != "" {
+                        regionKey = pref + "::" + city
+                }
+        }
+
+        // APIにリクエストを転送
+        resp, err := http.Post("https://api.daruks.com/weather", "application/json", bytes.NewBuffer(reqBody))
+        if err != nil {
+                http.Error(w, "failed to call weather API", http.StatusInternalServerError)
+                log.Println("weather API error:", err)
 		return
 	}
 	defer resp.Body.Close()
 
-	// APIのレスポンスをそのまま返す
-	apiRespBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		http.Error(w, "failed to read weather API response", http.StatusInternalServerError)
-		return
-	}
+        // APIのレスポンスを読み取る
+        apiRespBody, err := io.ReadAll(resp.Body)
+        if err != nil {
+                http.Error(w, "failed to read weather API response", http.StatusInternalServerError)
+                return
+        }
 
-	w.WriteHeader(resp.StatusCode)
-	w.Write(apiRespBody)
+        if resp.StatusCode >= 400 {
+                w.WriteHeader(resp.StatusCode)
+                w.Write(apiRespBody)
+                return
+        }
+
+        var upstream map[string]interface{}
+        if err := json.Unmarshal(apiRespBody, &upstream); err != nil {
+                // パースできない場合はそのまま返す
+                w.WriteHeader(resp.StatusCode)
+                w.Write(apiRespBody)
+                return
+        }
+
+        if regionKey != "" {
+                if merged, err := mergeWeatherResponse(regionKey, upstream); err == nil {
+                        upstream = merged
+                }
+        }
+
+        finalBody, err := json.Marshal(upstream)
+        if err != nil {
+                http.Error(w, "failed to encode weather response", http.StatusInternalServerError)
+                return
+        }
+
+        w.WriteHeader(resp.StatusCode)
+        w.Write(finalBody)
+}
+
+func mergeWeatherResponse(regionKey string, upstream map[string]interface{}) (map[string]interface{}, error) {
+        weatherCacheMu.Lock()
+        defer weatherCacheMu.Unlock()
+
+        body, _ := upstream["body"].(map[string]interface{})
+        if body == nil {
+                weatherCache[regionKey] = &cachedWeather{
+                        rawResponse: deepCopyMap(upstream),
+                        updatedAt:   time.Now(),
+                }
+                return upstream, nil
+        }
+
+        newMain, err := decodeWeatherMain(body["main_data"])
+        if err != nil {
+                weatherCache[regionKey] = &cachedWeather{
+                        rawResponse: deepCopyMap(upstream),
+                        updatedAt:   time.Now(),
+                }
+                return upstream, nil
+        }
+
+        var merged map[string]interface{}
+
+        if cached := weatherCache[regionKey]; cached != nil {
+                prevBody, _ := cached.rawResponse["body"].(map[string]interface{})
+                prevMain, err := decodeWeatherMain(prevBody["main_data"])
+                if err != nil {
+                        merged = mergeWeatherMain(nil, newMain)
+                } else {
+                        merged = mergeWeatherMain(prevMain, newMain)
+                }
+        } else {
+                merged = mergeWeatherMain(nil, newMain)
+        }
+
+        mergedBytes, err := json.Marshal(merged)
+        if err != nil {
+                return nil, err
+        }
+
+        body["main_data"] = string(mergedBytes)
+        upstream["body"] = body
+
+        weatherCache[regionKey] = &cachedWeather{
+                rawResponse: deepCopyMap(upstream),
+                updatedAt:   time.Now(),
+        }
+
+        return upstream, nil
+}
+
+func decodeWeatherMain(value interface{}) (map[string]interface{}, error) {
+        if value == nil {
+                return nil, nil
+        }
+
+        switch v := value.(type) {
+        case string:
+                trimmed := strings.TrimSpace(v)
+                if trimmed == "" {
+                        return map[string]interface{}{}, nil
+                }
+                var decoded map[string]interface{}
+                if err := json.Unmarshal([]byte(trimmed), &decoded); err != nil {
+                        return nil, err
+                }
+                return decoded, nil
+        case map[string]interface{}:
+                return deepCopyMap(v), nil
+        default:
+                return nil, errors.New("unsupported main_data format")
+        }
+}
+
+func mergeWeatherMain(prev, next map[string]interface{}) map[string]interface{} {
+        if prev == nil && next == nil {
+                return nil
+        }
+        if prev == nil {
+                return deepCopyMap(next)
+        }
+        if next == nil {
+                return deepCopyMap(prev)
+        }
+
+        result := deepCopyMap(prev)
+        for key, newVal := range next {
+                oldVal := result[key]
+                result[key] = mergeWeatherValue(oldVal, newVal)
+        }
+        return result
+}
+
+func mergeWeatherValue(oldVal, newVal interface{}) interface{} {
+        if newVal == nil {
+                return deepCopyValue(oldVal)
+        }
+
+        switch nv := newVal.(type) {
+        case string:
+                trimmed := strings.TrimSpace(nv)
+                if trimmed == "" || trimmed == "--" || trimmed == "--%" || strings.EqualFold(trimmed, "null") {
+                        if oldVal != nil {
+                                return deepCopyValue(oldVal)
+                        }
+                        return nv
+                }
+                return nv
+        case map[string]interface{}:
+                oldMap, _ := oldVal.(map[string]interface{})
+                return mergeWeatherMain(oldMap, nv)
+        case []interface{}:
+                oldSlice, _ := oldVal.([]interface{})
+                return mergeWeatherSlices(oldSlice, nv)
+        default:
+                return nv
+        }
+}
+
+func mergeWeatherSlices(oldSlice, newSlice []interface{}) []interface{} {
+        if oldSlice == nil && newSlice == nil {
+                return nil
+        }
+        if oldSlice == nil {
+                return deepCopySlice(newSlice)
+        }
+        if newSlice == nil {
+                return deepCopySlice(oldSlice)
+        }
+
+        maxLen := len(newSlice)
+        if len(oldSlice) > maxLen {
+                maxLen = len(oldSlice)
+        }
+
+        result := make([]interface{}, maxLen)
+        for i := 0; i < maxLen; i++ {
+                var oldVal interface{}
+                if i < len(oldSlice) {
+                        oldVal = oldSlice[i]
+                }
+                var newVal interface{}
+                if i < len(newSlice) {
+                        newVal = newSlice[i]
+                }
+                result[i] = mergeWeatherValue(oldVal, newVal)
+        }
+        return result
+}
+
+func deepCopyMap(src map[string]interface{}) map[string]interface{} {
+        if src == nil {
+                return nil
+        }
+        dst := make(map[string]interface{}, len(src))
+        for key, value := range src {
+                dst[key] = deepCopyValue(value)
+        }
+        return dst
+}
+
+func deepCopySlice(src []interface{}) []interface{} {
+        if src == nil {
+                return nil
+        }
+        dst := make([]interface{}, len(src))
+        for i, value := range src {
+                dst[i] = deepCopyValue(value)
+        }
+        return dst
+}
+
+func deepCopyValue(value interface{}) interface{} {
+        switch v := value.(type) {
+        case map[string]interface{}:
+                return deepCopyMap(v)
+        case []interface{}:
+                return deepCopySlice(v)
+        default:
+                return v
+        }
+}
+
+type pwaStatusResponse struct {
+        Available     bool   `json:"available"`
+        Platform      string `json:"platform,omitempty"`
+        SafariVersion string `json:"safariVersion,omitempty"`
+        Reason        string `json:"reason,omitempty"`
+        UserAgent     string `json:"userAgent,omitempty"`
+}
+
+func handlePWAStatus(w http.ResponseWriter, r *http.Request) {
+        if r.Method == http.MethodHead {
+                w.WriteHeader(http.StatusOK)
+                return
+        }
+
+        status := detectPWASupport(r.Header.Get("User-Agent"))
+        w.Header().Set("Content-Type", "application/json")
+        if err := json.NewEncoder(w).Encode(status); err != nil {
+                http.Error(w, "failed to encode response", http.StatusInternalServerError)
+        }
+}
+
+func detectPWASupport(ua string) pwaStatusResponse {
+        platform := "unknown"
+        switch {
+        case strings.Contains(ua, "iPad"):
+                platform = "iPadOS"
+        case strings.Contains(ua, "iPhone"):
+                platform = "iOS"
+        case strings.Contains(ua, "Macintosh"):
+                platform = "macOS"
+        case strings.Contains(ua, "Android"):
+                platform = "Android"
+        }
+
+        status := pwaStatusResponse{
+                Platform:  platform,
+                UserAgent: ua,
+        }
+
+        if ua == "" {
+                status.Reason = "user agent header is missing"
+                return status
+        }
+
+        major, fullVersion, err := parseSafariVersion(ua)
+        if err != nil {
+                status.Reason = "Safari version could not be detected"
+                return status
+        }
+
+        status.SafariVersion = fullVersion
+
+        if major >= 16 {
+                status.Available = true
+                status.Reason = "Safari supports progressive web apps"
+                return status
+        }
+
+        status.Reason = fmt.Sprintf("Safari %s does not meet the minimum requirement (16)", fullVersion)
+        return status
+}
+
+func parseSafariVersion(ua string) (int, string, error) {
+        idx := strings.Index(ua, "Version/")
+        if idx == -1 {
+                return 0, "", errors.New("version token not found")
+        }
+
+        start := idx + len("Version/")
+        end := start
+        for end < len(ua) {
+                c := ua[end]
+                if (c >= '0' && c <= '9') || c == '.' {
+                        end++
+                        continue
+                }
+                break
+        }
+
+        if end <= start {
+                return 0, "", errors.New("version string missing")
+        }
+
+        versionStr := ua[start:end]
+        parts := strings.Split(versionStr, ".")
+        major, err := strconv.Atoi(parts[0])
+        if err != nil {
+                return 0, "", err
+        }
+
+        return major, versionStr, nil
 }
 
 func handleWallpaperUpload(w http.ResponseWriter, r *http.Request) {

--- a/main.go
+++ b/main.go
@@ -5,23 +5,23 @@
 package main
 
 import (
-        "bytes"
-        "database/sql"
-        "encoding/json"
-        "errors"
-        "fmt"
-        "io"
-        "log"
-        "net/http"
-        "net/url"
-        "os"
-        "path/filepath"
-        "strconv"
-        "strings"
-        "sync"
-        "tabdock/getstatus"
-        "tabdock/subscription"
-        "time"
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"tabdock/getstatus"
+	"tabdock/subscription"
+	"time"
 
 	_ "modernc.org/sqlite"
 
@@ -35,38 +35,40 @@ const version = "5.8.1"
 var fallbackHolidays map[string]string
 
 var (
-        schedulePath  = "./json/schedule.json"
-        calendarDir   = "./home/assets/calendar"
-        forbiddenExts = map[string]bool{
-                ".htaccess": true, ".php": true, ".asp": true, ".aspx": true,
-                ".bat": true, ".cmd": true, ".exe": true, ".sh": true, ".dll": true,
-        }
-        mutex sync.Mutex
+	schedulePath  = "./json/schedule.json"
+	calendarDir   = "./home/assets/calendar"
+	forbiddenExts = map[string]bool{
+		".htaccess": true, ".php": true, ".asp": true, ".aspx": true,
+		".bat": true, ".cmd": true, ".exe": true, ".sh": true, ".dll": true,
+	}
+	mutex sync.Mutex
 )
 
 var (
-        weatherCache   = map[string]*cachedWeather{}
-        weatherCacheMu sync.Mutex
+	weatherCache          = map[string]*cachedWeather{}
+	weatherCacheMu        sync.Mutex
+	weatherNullTokensOnce sync.Once
+	weatherNullTokens     map[string]struct{}
 )
 
 type cachedWeather struct {
-        rawResponse map[string]interface{}
-        updatedAt   time.Time
+	rawResponse map[string]interface{}
+	updatedAt   time.Time
 }
 
 type weatherRequest struct {
-        Data struct {
-                PrefName string `json:"prefname"`
-                CityName string `json:"cityname"`
-        } `json:"data"`
+	Data struct {
+		PrefName string `json:"prefname"`
+		CityName string `json:"cityname"`
+	} `json:"data"`
 }
 
 type weatherBody struct {
-        MainData interface{} `json:"main_data"`
+	MainData interface{} `json:"main_data"`
 }
 
 type weatherAPIResponse struct {
-        Body weatherBody `json:"body"`
+	Body weatherBody `json:"body"`
 }
 
 // type
@@ -196,10 +198,10 @@ func main() {
 	mux.HandleFunc("/api/upload-profile-image", secureHandler(handleProfileImageUpload))
 
 	// Authentication APIs
-        mux.HandleFunc("/api/auth/login", secureHandler(handleAuthLogin))
-        mux.HandleFunc("/api/auth/register", secureHandler(handleAuthRegister))
-        mux.HandleFunc("/api/auth/user-info", secureHandler(handleUserInfo))
-        mux.HandleFunc("/api/auth/change-password", secureHandler(handleAuthChangePassword))
+	mux.HandleFunc("/api/auth/login", secureHandler(handleAuthLogin))
+	mux.HandleFunc("/api/auth/register", secureHandler(handleAuthRegister))
+	mux.HandleFunc("/api/auth/user-info", secureHandler(handleUserInfo))
+	mux.HandleFunc("/api/auth/change-password", secureHandler(handleAuthChangePassword))
 
 	// Subscription APIs
 	subscriptionDB, err := sql.Open("sqlite", "./database/subscription.db")
@@ -210,10 +212,10 @@ func main() {
 	mux.HandleFunc("/api/subscriptions", secureHandler(subHandler.Create))
 	mux.HandleFunc("/api/subscriptions/list", secureHandler(subHandler.GetUserSubscriptions))
 	mux.HandleFunc("/api/subscriptions/upcoming", secureHandler(subHandler.GetUpcoming))
-        mux.HandleFunc("/api/subscriptions/update", secureHandler(subHandler.Update))
-        mux.HandleFunc("/api/subscriptions/status", secureHandler(subHandler.UpdateStatus))
-        mux.HandleFunc("/api/subscriptions/delete", secureHandler(subHandler.Delete))
-        mux.HandleFunc("/api/pwa-status", secureHandler(handlePWAStatus))
+	mux.HandleFunc("/api/subscriptions/update", secureHandler(subHandler.Update))
+	mux.HandleFunc("/api/subscriptions/status", secureHandler(subHandler.UpdateStatus))
+	mux.HandleFunc("/api/subscriptions/delete", secureHandler(subHandler.Delete))
+	mux.HandleFunc("/api/pwa-status", secureHandler(handlePWAStatus))
 
 	// WebAuthn
 	mux.HandleFunc("/api/webauthn/register/start", secureHandler(HandleWebAuthnRegisterStart))
@@ -422,352 +424,403 @@ func getPCStatus() (*getstatus.PCStatus, error) {
 }
 
 func handleWeather(w http.ResponseWriter, r *http.Request) {
-        w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", "application/json")
 
-        // HEADリクエストならOKのみ返す
-        if r.Method == http.MethodHead {
-                w.WriteHeader(http.StatusOK)
-                return
-        }
+	// HEADリクエストならOKのみ返す
+	if r.Method == http.MethodHead {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
 
-        // クライアントからのリクエストボディを読み取る
-        reqBody, err := io.ReadAll(r.Body)
-        if err != nil {
-                http.Error(w, "failed to read request", http.StatusBadRequest)
-                return
-        }
+	// クライアントからのリクエストボディを読み取る
+	reqBody, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "failed to read request", http.StatusBadRequest)
+		return
+	}
 
-        var wReq weatherRequest
-        regionKey := ""
-        if err := json.Unmarshal(reqBody, &wReq); err == nil {
-                pref := strings.TrimSpace(wReq.Data.PrefName)
-                city := strings.TrimSpace(wReq.Data.CityName)
-                if pref != "" || city != "" {
-                        regionKey = pref + "::" + city
-                }
-        }
+	var wReq weatherRequest
+	regionKey := ""
+	if err := json.Unmarshal(reqBody, &wReq); err == nil {
+		pref := strings.TrimSpace(wReq.Data.PrefName)
+		city := strings.TrimSpace(wReq.Data.CityName)
+		if pref != "" || city != "" {
+			regionKey = pref + "::" + city
+		}
+	}
 
-        // APIにリクエストを転送
-        resp, err := http.Post("https://api.daruks.com/weather", "application/json", bytes.NewBuffer(reqBody))
-        if err != nil {
-                http.Error(w, "failed to call weather API", http.StatusInternalServerError)
-                log.Println("weather API error:", err)
+	// APIにリクエストを転送
+	resp, err := http.Post("https://api.daruks.com/weather", "application/json", bytes.NewBuffer(reqBody))
+	if err != nil {
+		http.Error(w, "failed to call weather API", http.StatusInternalServerError)
+		log.Println("weather API error:", err)
 		return
 	}
 	defer resp.Body.Close()
 
-        // APIのレスポンスを読み取る
-        apiRespBody, err := io.ReadAll(resp.Body)
-        if err != nil {
-                http.Error(w, "failed to read weather API response", http.StatusInternalServerError)
-                return
-        }
+	// APIのレスポンスを読み取る
+	apiRespBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		http.Error(w, "failed to read weather API response", http.StatusInternalServerError)
+		return
+	}
 
-        if resp.StatusCode >= 400 {
-                w.WriteHeader(resp.StatusCode)
-                w.Write(apiRespBody)
-                return
-        }
+	if resp.StatusCode >= 400 {
+		w.WriteHeader(resp.StatusCode)
+		w.Write(apiRespBody)
+		return
+	}
 
-        var upstream map[string]interface{}
-        if err := json.Unmarshal(apiRespBody, &upstream); err != nil {
-                // パースできない場合はそのまま返す
-                w.WriteHeader(resp.StatusCode)
-                w.Write(apiRespBody)
-                return
-        }
+	var upstream map[string]interface{}
+	if err := json.Unmarshal(apiRespBody, &upstream); err != nil {
+		// パースできない場合はそのまま返す
+		w.WriteHeader(resp.StatusCode)
+		w.Write(apiRespBody)
+		return
+	}
 
-        if regionKey != "" {
-                if merged, err := mergeWeatherResponse(regionKey, upstream); err == nil {
-                        upstream = merged
-                }
-        }
+	if regionKey != "" {
+		if merged, err := mergeWeatherResponse(regionKey, upstream); err == nil {
+			upstream = merged
+		}
+	}
 
-        finalBody, err := json.Marshal(upstream)
-        if err != nil {
-                http.Error(w, "failed to encode weather response", http.StatusInternalServerError)
-                return
-        }
+	finalBody, err := json.Marshal(upstream)
+	if err != nil {
+		http.Error(w, "failed to encode weather response", http.StatusInternalServerError)
+		return
+	}
 
-        w.WriteHeader(resp.StatusCode)
-        w.Write(finalBody)
+	w.WriteHeader(resp.StatusCode)
+	w.Write(finalBody)
 }
 
 func mergeWeatherResponse(regionKey string, upstream map[string]interface{}) (map[string]interface{}, error) {
-        weatherCacheMu.Lock()
-        defer weatherCacheMu.Unlock()
+	weatherCacheMu.Lock()
+	defer weatherCacheMu.Unlock()
 
-        body, _ := upstream["body"].(map[string]interface{})
-        if body == nil {
-                weatherCache[regionKey] = &cachedWeather{
-                        rawResponse: deepCopyMap(upstream),
-                        updatedAt:   time.Now(),
-                }
-                return upstream, nil
-        }
+	body, _ := upstream["body"].(map[string]interface{})
+	if body == nil {
+		weatherCache[regionKey] = &cachedWeather{
+			rawResponse: deepCopyMap(upstream),
+			updatedAt:   time.Now(),
+		}
+		return upstream, nil
+	}
 
-        newMain, err := decodeWeatherMain(body["main_data"])
-        if err != nil {
-                weatherCache[regionKey] = &cachedWeather{
-                        rawResponse: deepCopyMap(upstream),
-                        updatedAt:   time.Now(),
-                }
-                return upstream, nil
-        }
+	newMain, err := decodeWeatherMain(body["main_data"])
+	if err != nil {
+		weatherCache[regionKey] = &cachedWeather{
+			rawResponse: deepCopyMap(upstream),
+			updatedAt:   time.Now(),
+		}
+		return upstream, nil
+	}
 
-        var merged map[string]interface{}
+	var merged map[string]interface{}
 
-        if cached := weatherCache[regionKey]; cached != nil {
-                prevBody, _ := cached.rawResponse["body"].(map[string]interface{})
-                prevMain, err := decodeWeatherMain(prevBody["main_data"])
-                if err != nil {
-                        merged = mergeWeatherMain(nil, newMain)
-                } else {
-                        merged = mergeWeatherMain(prevMain, newMain)
-                }
-        } else {
-                merged = mergeWeatherMain(nil, newMain)
-        }
+	if cached := weatherCache[regionKey]; cached != nil {
+		prevBody, _ := cached.rawResponse["body"].(map[string]interface{})
+		prevMain, err := decodeWeatherMain(prevBody["main_data"])
+		if err != nil {
+			merged = mergeWeatherMain(nil, newMain)
+		} else {
+			merged = mergeWeatherMain(prevMain, newMain)
+		}
+	} else {
+		merged = mergeWeatherMain(nil, newMain)
+	}
 
-        mergedBytes, err := json.Marshal(merged)
-        if err != nil {
-                return nil, err
-        }
+	mergedBytes, err := json.Marshal(merged)
+	if err != nil {
+		return nil, err
+	}
 
-        body["main_data"] = string(mergedBytes)
-        upstream["body"] = body
+	body["main_data"] = string(mergedBytes)
+	upstream["body"] = body
 
-        weatherCache[regionKey] = &cachedWeather{
-                rawResponse: deepCopyMap(upstream),
-                updatedAt:   time.Now(),
-        }
+	weatherCache[regionKey] = &cachedWeather{
+		rawResponse: deepCopyMap(upstream),
+		updatedAt:   time.Now(),
+	}
 
-        return upstream, nil
+	return upstream, nil
 }
 
 func decodeWeatherMain(value interface{}) (map[string]interface{}, error) {
-        if value == nil {
-                return nil, nil
-        }
+	if value == nil {
+		return nil, nil
+	}
 
-        switch v := value.(type) {
-        case string:
-                trimmed := strings.TrimSpace(v)
-                if trimmed == "" {
-                        return map[string]interface{}{}, nil
-                }
-                var decoded map[string]interface{}
-                if err := json.Unmarshal([]byte(trimmed), &decoded); err != nil {
-                        return nil, err
-                }
-                return decoded, nil
-        case map[string]interface{}:
-                return deepCopyMap(v), nil
-        default:
-                return nil, errors.New("unsupported main_data format")
-        }
+	switch v := value.(type) {
+	case string:
+		trimmed := strings.TrimSpace(v)
+		if trimmed == "" {
+			return map[string]interface{}{}, nil
+		}
+		var decoded map[string]interface{}
+		if err := json.Unmarshal([]byte(trimmed), &decoded); err != nil {
+			return nil, err
+		}
+		return decoded, nil
+	case map[string]interface{}:
+		return deepCopyMap(v), nil
+	default:
+		return nil, errors.New("unsupported main_data format")
+	}
 }
 
 func mergeWeatherMain(prev, next map[string]interface{}) map[string]interface{} {
-        if prev == nil && next == nil {
-                return nil
-        }
-        if prev == nil {
-                return deepCopyMap(next)
-        }
-        if next == nil {
-                return deepCopyMap(prev)
-        }
+	if prev == nil && next == nil {
+		return nil
+	}
+	if prev == nil {
+		return deepCopyMap(next)
+	}
+	if next == nil {
+		return deepCopyMap(prev)
+	}
 
-        result := deepCopyMap(prev)
-        for key, newVal := range next {
-                oldVal := result[key]
-                result[key] = mergeWeatherValue(oldVal, newVal)
-        }
-        return result
+	result := deepCopyMap(prev)
+	for key, newVal := range next {
+		oldVal := result[key]
+		result[key] = mergeWeatherValue(oldVal, newVal)
+	}
+	return result
+}
+
+func initWeatherNullTokens() {
+	tokens := map[string]struct{}{
+		"":     {},
+		"null": {},
+		"n/a":  {},
+		"na":   {},
+	}
+
+	if extra := strings.TrimSpace(os.Getenv("WEATHER_NULL_TOKENS")); extra != "" {
+		for _, token := range strings.Split(extra, ",") {
+			trimmed := strings.ToLower(strings.TrimSpace(token))
+			if trimmed != "" {
+				tokens[trimmed] = struct{}{}
+			}
+		}
+	}
+
+	weatherNullTokens = tokens
+}
+
+func isNullishString(value string) bool {
+	weatherNullTokensOnce.Do(initWeatherNullTokens)
+
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return true
+	}
+
+	lower := strings.ToLower(trimmed)
+	if _, ok := weatherNullTokens[lower]; ok {
+		return true
+	}
+
+	if isHyphenPlaceholder(lower) {
+		return true
+	}
+
+	withoutPercent := strings.TrimSpace(strings.TrimSuffix(lower, "%"))
+	if isHyphenPlaceholder(withoutPercent) {
+		return true
+	}
+
+	return false
+}
+
+func isHyphenPlaceholder(value string) bool {
+	if value == "" {
+		return false
+	}
+	return strings.Trim(value, "-") == ""
 }
 
 func mergeWeatherValue(oldVal, newVal interface{}) interface{} {
-        if newVal == nil {
-                return deepCopyValue(oldVal)
-        }
+	if newVal == nil {
+		return deepCopyValue(oldVal)
+	}
 
-        switch nv := newVal.(type) {
-        case string:
-                trimmed := strings.TrimSpace(nv)
-                if trimmed == "" || trimmed == "--" || trimmed == "--%" || strings.EqualFold(trimmed, "null") {
-                        if oldVal != nil {
-                                return deepCopyValue(oldVal)
-                        }
-                        return nv
-                }
-                return nv
-        case map[string]interface{}:
-                oldMap, _ := oldVal.(map[string]interface{})
-                return mergeWeatherMain(oldMap, nv)
-        case []interface{}:
-                oldSlice, _ := oldVal.([]interface{})
-                return mergeWeatherSlices(oldSlice, nv)
-        default:
-                return nv
-        }
+	switch nv := newVal.(type) {
+	case string:
+		if isNullishString(nv) {
+			if oldVal != nil {
+				return deepCopyValue(oldVal)
+			}
+			return nv
+		}
+		return nv
+	case map[string]interface{}:
+		oldMap, _ := oldVal.(map[string]interface{})
+		return mergeWeatherMain(oldMap, nv)
+	case []interface{}:
+		oldSlice, _ := oldVal.([]interface{})
+		return mergeWeatherSlices(oldSlice, nv)
+	default:
+		return nv
+	}
 }
 
 func mergeWeatherSlices(oldSlice, newSlice []interface{}) []interface{} {
-        if oldSlice == nil && newSlice == nil {
-                return nil
-        }
-        if oldSlice == nil {
-                return deepCopySlice(newSlice)
-        }
-        if newSlice == nil {
-                return deepCopySlice(oldSlice)
-        }
+	if oldSlice == nil && newSlice == nil {
+		return nil
+	}
+	if oldSlice == nil {
+		return deepCopySlice(newSlice)
+	}
+	if newSlice == nil {
+		return deepCopySlice(oldSlice)
+	}
 
-        maxLen := len(newSlice)
-        if len(oldSlice) > maxLen {
-                maxLen = len(oldSlice)
-        }
+	maxLen := len(newSlice)
+	if len(oldSlice) > maxLen {
+		maxLen = len(oldSlice)
+	}
 
-        result := make([]interface{}, maxLen)
-        for i := 0; i < maxLen; i++ {
-                var oldVal interface{}
-                if i < len(oldSlice) {
-                        oldVal = oldSlice[i]
-                }
-                var newVal interface{}
-                if i < len(newSlice) {
-                        newVal = newSlice[i]
-                }
-                result[i] = mergeWeatherValue(oldVal, newVal)
-        }
-        return result
+	result := make([]interface{}, maxLen)
+	for i := 0; i < maxLen; i++ {
+		var oldVal interface{}
+		if i < len(oldSlice) {
+			oldVal = oldSlice[i]
+		}
+		var newVal interface{}
+		if i < len(newSlice) {
+			newVal = newSlice[i]
+		}
+		result[i] = mergeWeatherValue(oldVal, newVal)
+	}
+	return result
 }
 
 func deepCopyMap(src map[string]interface{}) map[string]interface{} {
-        if src == nil {
-                return nil
-        }
-        dst := make(map[string]interface{}, len(src))
-        for key, value := range src {
-                dst[key] = deepCopyValue(value)
-        }
-        return dst
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]interface{}, len(src))
+	for key, value := range src {
+		dst[key] = deepCopyValue(value)
+	}
+	return dst
 }
 
 func deepCopySlice(src []interface{}) []interface{} {
-        if src == nil {
-                return nil
-        }
-        dst := make([]interface{}, len(src))
-        for i, value := range src {
-                dst[i] = deepCopyValue(value)
-        }
-        return dst
+	if src == nil {
+		return nil
+	}
+	dst := make([]interface{}, len(src))
+	for i, value := range src {
+		dst[i] = deepCopyValue(value)
+	}
+	return dst
 }
 
 func deepCopyValue(value interface{}) interface{} {
-        switch v := value.(type) {
-        case map[string]interface{}:
-                return deepCopyMap(v)
-        case []interface{}:
-                return deepCopySlice(v)
-        default:
-                return v
-        }
+	switch v := value.(type) {
+	case map[string]interface{}:
+		return deepCopyMap(v)
+	case []interface{}:
+		return deepCopySlice(v)
+	default:
+		return v
+	}
 }
 
 type pwaStatusResponse struct {
-        Available     bool   `json:"available"`
-        Platform      string `json:"platform,omitempty"`
-        SafariVersion string `json:"safariVersion,omitempty"`
-        Reason        string `json:"reason,omitempty"`
-        UserAgent     string `json:"userAgent,omitempty"`
+	Available     bool   `json:"available"`
+	Platform      string `json:"platform,omitempty"`
+	SafariVersion string `json:"safariVersion,omitempty"`
+	Reason        string `json:"reason,omitempty"`
+	UserAgent     string `json:"userAgent,omitempty"`
 }
 
 func handlePWAStatus(w http.ResponseWriter, r *http.Request) {
-        if r.Method == http.MethodHead {
-                w.WriteHeader(http.StatusOK)
-                return
-        }
+	if r.Method == http.MethodHead {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
 
-        status := detectPWASupport(r.Header.Get("User-Agent"))
-        w.Header().Set("Content-Type", "application/json")
-        if err := json.NewEncoder(w).Encode(status); err != nil {
-                http.Error(w, "failed to encode response", http.StatusInternalServerError)
-        }
+	status := detectPWASupport(r.Header.Get("User-Agent"))
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(status); err != nil {
+		http.Error(w, "failed to encode response", http.StatusInternalServerError)
+	}
 }
 
 func detectPWASupport(ua string) pwaStatusResponse {
-        platform := "unknown"
-        switch {
-        case strings.Contains(ua, "iPad"):
-                platform = "iPadOS"
-        case strings.Contains(ua, "iPhone"):
-                platform = "iOS"
-        case strings.Contains(ua, "Macintosh"):
-                platform = "macOS"
-        case strings.Contains(ua, "Android"):
-                platform = "Android"
-        }
+	platform := "unknown"
+	switch {
+	case strings.Contains(ua, "iPad"):
+		platform = "iPadOS"
+	case strings.Contains(ua, "iPhone"):
+		platform = "iOS"
+	case strings.Contains(ua, "Macintosh"):
+		platform = "macOS"
+	case strings.Contains(ua, "Android"):
+		platform = "Android"
+	}
 
-        status := pwaStatusResponse{
-                Platform:  platform,
-                UserAgent: ua,
-        }
+	status := pwaStatusResponse{
+		Platform:  platform,
+		UserAgent: ua,
+	}
 
-        if ua == "" {
-                status.Reason = "user agent header is missing"
-                return status
-        }
+	if ua == "" {
+		status.Reason = "user agent header is missing"
+		return status
+	}
 
-        major, fullVersion, err := parseSafariVersion(ua)
-        if err != nil {
-                status.Reason = "Safari version could not be detected"
-                return status
-        }
+	major, fullVersion, err := parseSafariVersion(ua)
+	if err != nil {
+		status.Reason = "Safari version could not be detected"
+		return status
+	}
 
-        status.SafariVersion = fullVersion
+	status.SafariVersion = fullVersion
 
-        if major >= 16 {
-                status.Available = true
-                status.Reason = "Safari supports progressive web apps"
-                return status
-        }
+	if major >= 16 {
+		status.Available = true
+		status.Reason = "Safari supports progressive web apps"
+		return status
+	}
 
-        status.Reason = fmt.Sprintf("Safari %s does not meet the minimum requirement (16)", fullVersion)
-        return status
+	status.Reason = fmt.Sprintf("Safari %s does not meet the minimum requirement (16)", fullVersion)
+	return status
 }
 
 func parseSafariVersion(ua string) (int, string, error) {
-        idx := strings.Index(ua, "Version/")
-        if idx == -1 {
-                return 0, "", errors.New("version token not found")
-        }
+	idx := strings.Index(ua, "Version/")
+	if idx == -1 {
+		return 0, "", errors.New("version token not found")
+	}
 
-        start := idx + len("Version/")
-        end := start
-        for end < len(ua) {
-                c := ua[end]
-                if (c >= '0' && c <= '9') || c == '.' {
-                        end++
-                        continue
-                }
-                break
-        }
+	start := idx + len("Version/")
+	end := start
+	for end < len(ua) {
+		c := ua[end]
+		if (c >= '0' && c <= '9') || c == '.' {
+			end++
+			continue
+		}
+		break
+	}
 
-        if end <= start {
-                return 0, "", errors.New("version string missing")
-        }
+	if end <= start {
+		return 0, "", errors.New("version string missing")
+	}
 
-        versionStr := ua[start:end]
-        parts := strings.Split(versionStr, ".")
-        major, err := strconv.Atoi(parts[0])
-        if err != nil {
-                return 0, "", err
-        }
+	versionStr := ua[start:end]
+	parts := strings.Split(versionStr, ".")
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, "", err
+	}
 
-        return major, versionStr, nil
+	return major, versionStr, nil
 }
 
 func handleWallpaperUpload(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- cache upstream weather responses while merging null fields, add a /api/pwa-status probe, and surface GiB-based drive usage reporting
- add an authenticated change-password endpoint and update the account modal with a first-party password editor plus a data export SweetAlert flow
- refresh the devtools experience with categorized menus, richer diagnostics, burn-in sleep handling, and expanded subscription filtering/notifications

## Testing
- go test ./... *(fails: command timed out locally)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f55875154832aa49777e501fbcaf7)