### PR TITLE
Potential fix for code scanning alert no. 3: Cookie 'Secure' attribute is not set to true

### DIFF
--- a/logon.go
+++ b/logon.go
@@ -417,7 +417,7 @@ func setSessionCookie(w http.ResponseWriter, r *http.Request, username string) e
 		Path:     "/",
 		Expires:  expiresAt,
 		HttpOnly: true,
-		Secure:   shouldUseSecureCookie(r),
+		Secure:   true,
 		SameSite: http.SameSiteLaxMode,
 	})
 
@@ -449,7 +449,7 @@ func setDeviceIDCookie(w http.ResponseWriter, r *http.Request, deviceID string) 
 		Path:     "/",
 		Expires:  expiresAt,
 		HttpOnly: true,
-		Secure:   shouldUseSecureCookie(r),
+		Secure:   true,
 		SameSite: http.SameSiteLaxMode,
 	})
 


### PR DESCRIPTION
Potential fix for [https://github.com/darui3018823/tabdock/security/code-scanning/3](https://github.com/darui3018823/tabdock/security/code-scanning/3)

In general, the fix is to ensure that cookies carrying authentication or other sensitive data are always marked `Secure: true`, so they are only sent over HTTPS. Relying on request properties like `r.TLS` is fragile and can allow cookies over HTTP in misconfigured or local setups.

For this specific code, the best minimal-impact fix is:

- In `setSessionCookie`, replace `Secure:   shouldUseSecureCookie(r),` with `Secure:   true,` so the session cookie is always secure.
- In `setDeviceIDCookie`, do the same replacement to avoid leaking device identifiers over HTTP, which might be used for tracking or security decisions.

These are both in `logon.go`. No new imports or methods are needed; we are just changing the cookie struct literals. This preserves all existing functionality except that the cookies will now only be sent over HTTPS, which is exactly the desired security property.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
