### PR TITLE
fix: resolve golangci-lint issues

### DIFF
--- a/logon.go
+++ b/logon.go
@@ -330,19 +330,6 @@ func getRestoreTokenTTL() time.Duration {
 	return restoreTTL
 }
 
-func shouldUseSecureCookie(r *http.Request) bool {
-	switch strings.ToLower(strings.TrimSpace(getEnv("COOKIE_SECURE", "auto"))) {
-	case "true", "1", "yes", "on":
-		return true
-	case "false", "0", "no", "off":
-		return false
-	default:
-		if r.TLS != nil {
-			return true
-		}
-		return strings.EqualFold(strings.TrimSpace(r.Header.Get("X-Forwarded-Proto")), "https")
-	}
-}
 
 func createSessionCookieValue(username string, now time.Time) (string, time.Time, error) {
 	if strings.TrimSpace(username) == "" {
@@ -412,7 +399,7 @@ func parseAndVerifySessionCookieValue(value string) (string, error) {
 	return username, nil
 }
 
-func setSessionCookie(w http.ResponseWriter, r *http.Request, username string) error {
+func setSessionCookie(w http.ResponseWriter, _ *http.Request, username string) error {
 	value, expiresAt, err := createSessionCookieValue(username, time.Now())
 	if err != nil {
 		return err
@@ -439,7 +426,7 @@ func getDeviceIDFromCookie(r *http.Request) string {
 	return strings.TrimSpace(cookie.Value)
 }
 
-func setDeviceIDCookie(w http.ResponseWriter, r *http.Request, deviceID string) (string, error) {
+func setDeviceIDCookie(w http.ResponseWriter, _ *http.Request, deviceID string) (string, error) {
 	id := strings.TrimSpace(deviceID)
 	if id == "" {
 		bytes, err := randomBytes(16)

--- a/wallpaper/handler.go
+++ b/wallpaper/handler.go
@@ -22,6 +22,7 @@ import (
 
 // Upload limits and storage settings.
 const (
+	statusSuccess = "success"
 	MaxFileSize  = 50 << 20 // 50MB
 	WallpaperDir = "home/wallpapers"
 	KiloBytes    = 1024
@@ -115,7 +116,7 @@ func (h *Handler) Upload(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(map[string]string{
-		"status":   "success",
+		"status":   statusSuccess,
 		"filename": filename,
 	}); err != nil {
 		log.Printf("Failed to encode response: %v", err)
@@ -149,7 +150,7 @@ func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(map[string]interface{}{
-		"status": "success",
+		"status": statusSuccess,
 		"images": files,
 	}); err != nil {
 		log.Printf("Failed to encode response: %v", err)
@@ -192,7 +193,7 @@ func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(map[string]interface{}{
-		"success": true,
+		statusSuccess: true,
 		"message": "壁紙を削除しました",
 	}); err != nil {
 		log.Printf("Failed to encode response: %v", err)


### PR DESCRIPTION
## Summary

Fixes 4 golangci-lint issues blocking all Dependabot PRs (#69–#72):

- `wallpaper/handler.go`: extract `"success"` string to constant `statusSuccess` (goconst)
- `logon.go`: rename unused `r *http.Request` parameter to `_` in `setSessionCookie` and `setDeviceIDCookie` (revive)
- `logon.go`: remove unused function `shouldUseSecureCookie` (unused)

## Test plan

- [ ] golangci-lint passes
- [ ] Build passes